### PR TITLE
fixed bug with sorting fields

### DIFF
--- a/src/routes/settings/fields.vue
+++ b/src/routes/settings/fields.vue
@@ -488,10 +488,7 @@ export default {
               name: formatTitle(field.field)
             }))
             .sort((a, b) => {
-              if (a.sort == null) return 1;
-              if (b.sort == null) return -1;
-              if (a.sort == b.sort) return 0;
-              return a.sort > b.sort ? 1 : -1;
+              return a - b;
             });
         });
       })


### PR DESCRIPTION
Please check. Now the fields is in right order even if you just created new collection with fields and did a page refresh for example