### PR TITLE
add placeholder text

### DIFF
--- a/src/components/extension/interface/input/input.vue
+++ b/src/components/extension/interface/input/input.vue
@@ -83,6 +83,10 @@ export default {
     values: {
       type: Object,
       default: null
+    },
+    placeholder: {
+      type: String,
+      default: null
     }
   },
   computed: {
@@ -109,7 +113,8 @@ export default {
 
       return {
         ...defaults,
-        ...this.options
+        ...this.options,
+        placeholder: this.placeholder
       };
     }
   },

--- a/src/components/field-setup.vue
+++ b/src/components/field-setup.vue
@@ -236,7 +236,8 @@
             :required="option.required"
             :loading="option.loading"
             :options="option.options"
-            :value="options[optionID] || option.default"
+            :placeholder="option.default"
+            :value="options[optionID]"
             :fields="selectedInterfaceInfo.options"
             :values="options"
             @input="$set(options, optionID, $event)" />


### PR DESCRIPTION
Fixes issue [939](https://github.com/directus/app/issues/939)

Allows users to clear default text in input fields, then displays the default text using input placeholder if  left empty