### PR TITLE
Add placeholder for disabled length field

### DIFF
--- a/src/components/field-setup.vue
+++ b/src/components/field-setup.vue
@@ -134,6 +134,7 @@
                 @input="length = $event;"
                 :value="lengthDisabled ? null : length"
                 :disabled="lengthDisabled"
+                :placeholder="lengthDisabled ? $t('length_disabled_placeholder') : ''"
             /></label>
             <label
               >{{ $t("validation") }}

--- a/src/lang/locales/en-US.js
+++ b/src/lang/locales/en-US.js
@@ -267,6 +267,7 @@ export default {
   learn_more: "Learn More",
   leave_comment: "Leave a comment...",
   length: "Length",
+  length_disabled_placeholder: "Length is determined by the datatype",
   less_than_equal: "Less than or equal to",
   less_than: "Less than",
   limited: "Limited",


### PR DESCRIPTION
Adds placeholder to a disabled Length field in Settings -> Collection & Fields. Please see screenshot attached below.

![1070-example](https://user-images.githubusercontent.com/5573513/48670037-3ac13e80-eac5-11e8-83e2-a0902dcb6dd1.png)


Closes #1070 
