### PR TITLE
Allow passing accept prop to the upload component

### DIFF
--- a/src/components/upload.vue
+++ b/src/components/upload.vue
@@ -8,6 +8,7 @@
       class="select"
       type="file"
       ref="select"
+      :accept="accept"
       :multiple="multiple"
       @change="filesChange($event.target.files)"
     />
@@ -71,6 +72,7 @@
       class="drop"
       type="file"
       ref="drop"
+      :accept="accept"
       :multiple="multiple"
       @click.prevent
       @change="filesChange($event.target.files)"
@@ -84,6 +86,9 @@ import filesize from "filesize";
 export default {
   name: "v-upload",
   props: {
+    accept: {
+      type: String
+    },
     multiple: {
       type: Boolean,
       default: true


### PR DESCRIPTION
I had a go at fixing #727 

This is the easy part which just adds an `accept` option to the `v-upload` component; the main part of the fix is using the property in the `file` and `files` input types in https://github.com/directus/api/pull/747