### PR TITLE
Use updateItem for system collections

### DIFF
--- a/src/store/modules/edits/actions.js
+++ b/src/store/modules/edits/actions.js
@@ -52,6 +52,15 @@ export function save({ commit, state, rootState }, overrides) {
       return res;
     });
   }
+  
+  if (info.collection.startsWith("directus_")) {
+    return api
+      .updateItem(info.collection, info.primaryKey, info.values)
+      .then(res => {
+        commit(ITEM_CREATED);
+        return res;
+      });
+  }
 
   return api
     .patch("/items/" + info.collection + "/" + info.primaryKey, info.values, {


### PR DESCRIPTION
Commit #b27304e introduced a bug that prevents you from updating system tables.  In particular when trying to update a user the app would try to update /item/directus_users instead of /users resulting with the error "Direct Access to System collections are not allowed".

This patch implements the same system table test from the JS-SDK and calls the original api.updateItem for system tables.