### PR TITLE
Handle invalid collection name

### DIFF
--- a/src/lang/locales/en-US.js
+++ b/src/lang/locales/en-US.js
@@ -56,6 +56,7 @@ export default {
   connection: "Connection",
   collection: "Collection",
   collections_and_fields: "Collection & Fields",
+  collection_invalid_name: "Invalid collection name",
   collection_updated: "{collection} Collection Updated",
   collection_removed: "{collection} Collection Removed",
   collection_names_cannot_be_changed:

--- a/src/routes/settings/collections.vue
+++ b/src/routes/settings/collections.vue
@@ -523,6 +523,7 @@ export default {
           this.$router.push(`/settings/collections/${this.newName}`);
         })
         .catch(error => {
+          this.adding = false;
           this.$store.dispatch("loadingFinished", id);
           this.$events.emit("error", {
             notify: this.$t("something_went_wrong_body"),

--- a/src/routes/settings/collections.vue
+++ b/src/routes/settings/collections.vue
@@ -525,10 +525,19 @@ export default {
         .catch(error => {
           this.adding = false;
           this.$store.dispatch("loadingFinished", id);
-          this.$events.emit("error", {
-            notify: this.$t("something_went_wrong_body"),
-            error
-          });
+          if (error) {
+            // Use bit more descriptive error if possible
+            const errors = {
+              4: this.$t("collection_invalid_name")
+            };
+            this.$events.emit("error", {
+              notify:
+                error.code in errors
+                  ? errors[error.code]
+                  : this.$t("something_went_wrong_body"),
+              error
+            });
+          }
         });
     },
     toggleManage(collection) {

--- a/src/routes/settings/roles.vue
+++ b/src/routes/settings/roles.vue
@@ -120,6 +120,7 @@ export default {
           this.$router.push(`/settings/roles/${role.id}`);
         })
         .catch(error => {
+          this.adding = false;
           this.$store.dispatch("loadingFinished", id);
           this.$events.emit("error", {
             notify: this.$t("something_went_wrong_body"),


### PR DESCRIPTION
This PR fixes two minor issues related to collection creation modal dialog

**Stop the indicator from spinning if error occurred**
> Fixes an issue where indicator would not stop spinning even when response was
received.


**Add error message for invalid name**
> Currently this is the only way the API will return error code 4 using this form
is for the user to provide invalid name.