### PR TITLE
Manual sort allow desc

### DIFF
--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -341,13 +341,12 @@ export default {
     },
     updateSort(field, direction) {
 
-      var newSortVal = {
+      const newSortVal = {
         field,
         asc: field === this.sortVal.field ? !this.sortVal.asc : "ASC"
       };
 
-      if ((field == this.manualSortField) && this.manualSorting) {
-      } else {
+      if (!(field == this.manualSortField) && !this.manualSorting) {
         this.manualSorting = false;
       }
 

--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -339,20 +339,20 @@ export default {
       return this.$emit("select", primaryKeyFields);
     },
     updateSort(field, direction) {
-      this.manualSorting = false;
 
-      if (direction) {
-        const newSortVal = {
-          field,
-          asc: direction === "asc"
-        };
-        return this.$emit("sort", newSortVal);
-      }
-
-      const newSortVal = {
+      var newSortVal = {
         field,
         asc: field === this.sortVal.field ? !this.sortVal.asc : "ASC"
       };
+
+      if ((field == this.manualSortField) && this.manualSorting) {
+      } else {
+        this.manualSorting = false;
+      }
+
+      if (direction) {
+        newSortVal.asc = (direction === "asc")
+      }
 
       this.$emit("sort", newSortVal);
     },
@@ -412,7 +412,6 @@ export default {
         return;
       }
 
-      this.updateSort(this.manualSortField, "asc");
       this.manualSorting = true;
     },
     startSort() {


### PR DESCRIPTION
For #1261
Basically if the sort field is visible on the table and already sorted, switching to manual mode will not change the sort view and works like normal