### PR TITLE
Fix drag and drop not working with v-upload accept prop

### DIFF
--- a/src/components/upload.vue
+++ b/src/components/upload.vue
@@ -123,6 +123,15 @@ export default {
       embed: false
     };
   },
+  computed: {
+    acceptTypesList() {
+      if (this.accept) {
+        return this.accept.trim().split(/\s*,\s*/)
+      } else {
+        return []
+      }
+    }
+  },
   methods: {
     saveEmbed() {
       this.$api
@@ -157,6 +166,14 @@ export default {
       if (size !== -1 && size > this.$store.state.serverInfo.maxUploadSize) {
         this.$events.emit("warning", {
           notify: this.$t("upload_exceeds_max_size", { filename: name })
+        });
+
+        return;
+      }
+
+      if (this.acceptTypesList.length > 0 && !this.acceptTypesList.includes(type)) {
+        this.$events.emit("warning", {
+          notify: this.$t("file_type_not_accepted", { filename: name })
         });
 
         return;

--- a/src/lang/locales/en-US.js
+++ b/src/lang/locales/en-US.js
@@ -457,5 +457,7 @@ export default {
   duplicating_field: "Duplicating Field",
   duplicate: "Duplicate",
   upload_exceeds_max_size:
-    "{filename} can't be uploaded. Your server is not configured to handle uploads of this size."
+    "{filename} can't be uploaded. Your server is not configured to handle uploads of this size.",
+  file_type_not_accepted:
+    "{filename} can't be uploaded. It is not a valid file type for this field."
 };


### PR DESCRIPTION
Based on feedback on https://github.com/directus/api/pull/747

TIL file inputs ignore the `accept` attribute when you drag and drop files (https://stackoverflow.com/questions/49001554/file-field-accept-attribute-not-working-properly-when-drag-and-drop-file-into), so that needs to be handled separately in the `v-upload` component.

This makes the same assumption as the `file` and `files` interfaces, that `accept` is a comma-separated list of specific MIME types, not the full syntax supported by HTML.