### PR TITLE
sdk will always return not logged in if dont set localExp time for sdk;

### DIFF
--- a/src/store/modules/auth/actions.js
+++ b/src/store/modules/auth/actions.js
@@ -97,6 +97,7 @@ export function loginSSO({ commit }, request_token) {
     .then(res => res.data)
     .then(({ token }) => {
       api.token = token;
+      api.localExp = new Date(Date.now() + 5 * 60000).getTime();
       commit(LOGIN_SUCCESS, {
         project: project,
         url,


### PR DESCRIPTION
login from SSO doesn't create a default value of localExp in sdk,  
and sdk loggedIn's value depends on localExp,  
this will cause loggedIn forever false.
so give a default value for localExp when login from sso