### PR TITLE
Allow for optional time and deleting time entries

### DIFF
--- a/src/interfaces/time/input.vue
+++ b/src/interfaces/time/input.vue
@@ -15,7 +15,8 @@ export default {
   mixins: [mixin],
   methods: {
     emitValue(value) {
-      if (value.length !== 8) value = value + ":00";
+      if (value.length === 5) value = value + ":00";
+      if (value.length === 0) value = null;
 
       this.$emit("input", value);
     }


### PR DESCRIPTION
With the arbitrary adding of ":00" it doesn't allow for submitting empty time entries. It also needs set to null because the API assumes midnight if it is an empty string.