### PR TITLE
Fixes simple-select component to show selected value

### DIFF
--- a/src/components/form-inputs/simple-select.vue
+++ b/src/components/form-inputs/simple-select.vue
@@ -50,12 +50,7 @@ export default {
     getValueNames() {
       const selectElement = this.$refs.selectElement;
       const valueNames = {};
-
-      const children = Array.from(selectElement.children)
-        .filter(element => {
-          return element.tagName.toLowerCase() === "option";
-        })
-        .filter(element => element.value);
+      const children = Array.from(selectElement.querySelectorAll("option"));
 
       children.forEach(element => {
         valueNames[element.value] = element.innerText;
@@ -66,6 +61,11 @@ export default {
   },
   mounted() {
     this.getValueNames();
+  },
+  watch: {
+    value() {
+      this.getValueNames();
+    }
   }
 };
 </script>


### PR DESCRIPTION
fixes bug: #1581

Fixes the wrong traversing through the options. `element.children` only traverses one level down the DOM, which is not sufficient, because in some cases there are `optgroups`, which then have multiple options. Also it is important to add the `watch` to values again, otherwise the `valueNames` won't get updated when for example a new `junction_collection` is selected.