### PR TITLE
Removed a watch function on the advanced WYSIWYG editor.

### DIFF
--- a/src/interfaces/wysiwyg-full/input.vue
+++ b/src/interfaces/wysiwyg-full/input.vue
@@ -48,13 +48,6 @@ export default {
       }
     };
   },
-  watch: {
-    value(newVal) {
-      if (newVal !== this.editor.root.innerHTML) {
-        this.editor.setContents(this.editor.clipboard.convert(this.value));
-      }
-    }
-  },
   mounted() {
     this.init();
   },


### PR DESCRIPTION
Fixes #1431, fixes #1319 

The watch block seems to be used to keep the value in sync with the editor, which is already accomplished by providing the editor ref while creating the Quill instance, making this a redundant piece of code.

This is my first pull request, so please let me know if there's any additional information I can provide, or details I need to add to push this through. :)