### PR TITLE
Adjusted publicPath settings.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,14 +5,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="shortcut icon" href="<%= webpackConfig.output.publicPath %>favicon.ico">
-    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="manifest" href="<%= webpackConfig.output.publicPath %>manifest.webmanifest" />
     <title>Directus</title>
-
-    <% if (process.env.NODE_ENV === "development") { %>
-    <link rel="stylesheet" href="/style.css" />
-    <% } else { %>
-    <link rel="stylesheet" href="./style.css" />
-    <% } %>
+    <link rel="stylesheet" href="<%= webpackConfig.output.publicPath %>style.css" />
   </head>
   <body>
     <noscript>
@@ -21,12 +16,7 @@
     <div id="app"></div>
     <!-- built files will be auto injected -->
 
-    <% if (process.env.NODE_ENV === "development") { %>
-    <script src="/config.js"></script>
-    <script src="/script.js"></script>
-    <% } else { %>
-    <script src="./config.js"></script>
-    <script src="./script.js"></script>
-    <% } %>
+    <script src="<%= webpackConfig.output.publicPath %>config.js"></script>
+    <script src="<%= webpackConfig.output.publicPath %>script.js"></script>
   </body>
 </html>

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   lintOnSave: false,
-  publicPath: process.env.NODE_ENV === "production" ? "" : "/",
+  publicPath: process.env.PUBLIC_PATH || "/",
 
   // There are so many chunks (from all the interfaces / layouts) that we need to make sure to not
   // prefetch them all. Prefetching them all will cause the server to apply rate limits in most cases

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   lintOnSave: false,
-  publicPath: process.env.PUBLIC_PATH || "/",
+  publicPath: process.env.PUBLIC_PATH || (process.env.NODE_ENV === "production" ? "" : "/"),
 
   // There are so many chunks (from all the interfaces / layouts) that we need to make sure to not
   // prefetch them all. Prefetching them all will cause the server to apply rate limits in most cases


### PR DESCRIPTION
I had the following issue in history routing mode:

In production, CSS and JS resource wouldn't load on routes like `/collections/test`. Since the browser would see them as `/collections/test/css/chunk-0bea28e8.996feaa2.css`, instead of `/css/chunk-0bea28e8.996feaa2.css`.

I made some modification, and this worked for me both in `history` and `hash` mode. It also worked when the app is in a subdirectory.

When the app is deployed in a subdirectory the build needs to be executed as such: `env PUBLIC_PATH=/subd/ npm run build`
Also the `config.js` property `routerBaseUrl` needs to be `/subd/`.

Can someone please see if this issue can be replicated, and if this fixes it. Or if something else is required.