### PR TITLE
Fix #1278

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -50,7 +50,7 @@ export function resetState() {
   // the store.replaceState method will make the passed in object reactive.
   // This will make a clone to modify, so the original initialStateCopy stays
   // as-is
-  const newState = Object.assign({}, initialStateCopy);
+  const newState = JSON.parse(JSON.stringify(initialStateCopy));
   newState.auth.projectName = store.state.auth.projectName;
   newState.auth.project = store.state.auth.project;
   newState.auth.url = store.state.auth.url;


### PR DESCRIPTION
```js
const newState = Object.assign({},initialStateCopy);
```
Somehow here `newState` was keep referencing the `initialStateCopy`. Changed that to `JSON.parse(JSON.stringify(initialStateCopy))` and all working fine! 🤔

@rijkvanzanten  Any idea why such behavior?

Fixes #1278