### PR TITLE
Fix #1966 [Resolve : Card layout displays [object Object]]

### DIFF
--- a/src/components/card/card.vue
+++ b/src/components/card/card.vue
@@ -46,11 +46,17 @@
       </div>
       <div class="body" :class="{ menu: options != null }">
         <div class="main">
-          <component :is="titleElement" v-tooltip="title" class="title">
-            {{ title }}
-          </component>
+          <slot name="title">
+            <component :is="titleElement" v-tooltip="title" class="title">
+              {{ title }}
+            </component>
+          </slot>
+          <!-- <slot name="subtitle"> -->
           <p v-if="subtitle" class="subtitle">{{ subtitle }}</p>
+          <!-- </slot>
+          <slot name="content"> -->
           <p v-if="body" class="content">{{ body }}</p>
+          <!-- </slot> -->
         </div>
         <v-contextual-menu
           :disabled="disabled"
@@ -88,7 +94,7 @@ export default {
     },
     title: {
       type: String,
-      required: true
+      default: null
     },
     subtitle: {
       type: String,

--- a/src/layouts/cards/layout.vue
+++ b/src/layouts/cards/layout.vue
@@ -26,7 +26,6 @@
         v-for="item in items"
         :key="item.id"
         :to="item[link]"
-        :title="title(item)"
         :subtitle="subtitle(item)"
         :icon="emptySrc(item) ? viewOptions.icon || 'photo' : null"
         :opacity="emptySrc(item) ? 'half' : null"
@@ -35,7 +34,21 @@
         :selected="selection.includes(item.id)"
         :selection-mode="selection.length > 0"
         @select="select(item.id)"
-      ></v-card>
+      >
+        <template slot="title">
+          <v-ext-display
+            :id="title"
+            class="title"
+            :interface-type="fields[title].interface"
+            :name="title"
+            :collection="collection"
+            :type="fields[title].type"
+            :options="fields[title].options"
+            :value="item[title]"
+            :relation="fields[title].relation"
+          />
+        </template>
+      </v-card>
       <v-card
         v-if="lazyLoading"
         color="dark-gray"
@@ -58,6 +71,9 @@ export default {
   name: "LayoutCards",
   mixins: [mixin],
   computed: {
+    title() {
+      return this.viewOptions.title || this.primaryKeyField;
+    },
     sortableFields() {
       return _.pickBy(this.fields, field => field.datatype);
     },
@@ -93,10 +109,6 @@ export default {
     }
   },
   methods: {
-    title(item) {
-      const titleField = this.viewOptions.title || this.primaryKeyField;
-      return String(item[titleField]);
-    },
     subtitle(item) {
       const subtitleField = this.viewOptions.subtitle || null;
 


### PR DESCRIPTION
@theharshin — This issue can be solved with using `slot` as right now it is rendering via `props`.

I already used `slot` in this PR and for that, the dynamic render of extension must be there as it should be changed as per the value selected in view option(info bar).

Right now extensions are not being loaded at a run time and throwing an error when the value is getting changed from view option. You can find that error below.

![image](https://user-images.githubusercontent.com/19200178/63261611-86e21f00-c2a1-11e9-91fd-7355d47bbe70.png)

Kindly look into it so we can merge this PR.