### PR TITLE
#1802 : Finish file progress after API response

### DIFF
--- a/src/components/upload.vue
+++ b/src/components/upload.vue
@@ -212,11 +212,12 @@ export default {
 
       this.$api
         .uploadFiles(formData, ({ loaded, total }) => {
-          const progress = Math.round((loaded * 100) / total);
+          const progress = Math.min(Math.round((loaded * 100) / total), 95);
           this.files[id].progress = progress;
         })
         .then(res => res.data)
         .then(res => {
+          this.files[id].progress = 100;
           this.$emit("upload", {
             ...this.files[id],
             data: res


### PR DESCRIPTION
Applied change in **.uploadFiles** event that file progress reaches a maximum of 95% and complete 100% after getting actual API response.