### PR TITLE
Fix/1993 [Preview Field URL Doesn't Contain Variable in List View]

### DIFF
--- a/src/components/item-select/item-select.vue
+++ b/src/components/item-select/item-select.vue
@@ -94,6 +94,7 @@
               :datatype="fieldInfo.datatype"
               :options="fieldInfo.options"
               :value="item[fieldInfo.field]"
+              :values="getItemValueByID(item.id)"
             />
           </span>
         </label>
@@ -284,6 +285,14 @@ export default {
         params.fields = []; // ISSUE#1865 Fixed Define the blank fields array to push the data.
       }
 
+      const fieldsData = this.fields.map(fieldName => {
+        return this.$store.state.collections[this.collection].fields[fieldName];
+      });
+
+      // ISSUE#1993 Preview Field URL Doesn't Contain Variable in List
+      var result = fieldsData.filter(field => field.type.toLowerCase() === "alias");
+      if (result.length > 0) params.fields = ["*.*"];
+
       let sortString = "";
       if (this.sortDirection === "desc") sortString += "-";
       if (this.sortField) sortString += this.sortField;
@@ -346,6 +355,10 @@ export default {
         offset: offset,
         replace: false
       });
+    },
+    getItemValueByID(id) {
+      var value = this.items.filter(item => item.id == id);
+      return Object.assign({}, value[0]);
     }
   }
 };

--- a/src/components/item-select/item-select.vue
+++ b/src/components/item-select/item-select.vue
@@ -94,7 +94,7 @@
               :datatype="fieldInfo.datatype"
               :options="fieldInfo.options"
               :value="item[fieldInfo.field]"
-              :values="getItemValueByID(item.id)"
+              :values="getItemValueById(item.id)"
             />
           </span>
         </label>
@@ -285,11 +285,10 @@ export default {
         params.fields = []; // ISSUE#1865 Fixed Define the blank fields array to push the data.
       }
 
+      // ISSUE#1993 Preview Field URL Doesn't Contain Variable in List
       const fieldsData = this.fields.map(fieldName => {
         return this.$store.state.collections[this.collection].fields[fieldName];
       });
-
-      // ISSUE#1993 Preview Field URL Doesn't Contain Variable in List
       var result = fieldsData.filter(field => field.type.toLowerCase() === "alias");
       if (result.length > 0) params.fields = ["*.*"];
 
@@ -356,7 +355,7 @@ export default {
         replace: false
       });
     },
-    getItemValueByID(id) {
+    getItemValueById(id) {
       var value = this.items.filter(item => item.id == id);
       return Object.assign({}, value[0]);
     }

--- a/src/components/item-select/item-select.vue
+++ b/src/components/item-select/item-select.vue
@@ -356,8 +356,8 @@ export default {
       });
     },
     getItemValueById(id) {
-      var value = this.items.filter(item => item.id == id);
-      return Object.assign({}, value[0]);
+      const value = this.items.filter(item => item.id == id)[0];
+      return Object.assign({}, value);
     }
   }
 };

--- a/src/components/items.vue
+++ b/src/components/items.vue
@@ -393,9 +393,8 @@ export default {
       Object.assign(params, this.viewQuery);
 
       if (this.viewQuery && this.viewQuery.fields) {
-        if (params.fields instanceof Array == false)
-          params.fields = params.fields.split(",");
-          
+        if (params.fields instanceof Array == false) params.fields = params.fields.split(",");
+
         params.fields = params.fields.map(field => `${field}.*`);
 
         if (!params.fields.includes(this.primaryKeyField)) {
@@ -406,6 +405,11 @@ export default {
       } else {
         params.fields = "*.*";
       }
+
+      // ISSUE#1993 Preview Field URL Doesn't Contain Variable in List
+      const fieldValues = Object.values(this.fields);
+      var result = fieldValues.filter(field => field.type.toLowerCase() === "alias");
+      if (result.length > 0) params.fields = "*.*";
 
       if (this.searchQuery) {
         params.q = this.searchQuery;

--- a/src/components/items.vue
+++ b/src/components/items.vue
@@ -60,6 +60,7 @@
 
 <script>
 import formatFilters from "../helpers/format-filters";
+import getFieldsFromTemplate from "@/helpers/get-fields-from-template";
 
 export default {
   name: "VItems",
@@ -401,15 +402,26 @@ export default {
           params.fields.push(this.primaryKeyField);
         }
 
+        // ISSUE#1993 Preview Field URL Doesn't Contain Variable in List
+        const aliasFields = Object.values(this.fields).filter(
+          field => field.type.toLowerCase() === "alias"
+        );
+        if (aliasFields.length > 0) {
+          _.forEach(aliasFields, function(value) {
+            if (value.options.url_template.match(/{{(.*)}}/g)) {
+              const templateFields = getFieldsFromTemplate(value.options.url_template)[0];
+              const field = templateFields.split(".")[0];
+              if (!params.fields.includes(`${field}.*`) && !params.fields.includes(field)) {
+                params.fields.push(`${field}.*`);
+              }
+            }
+          });
+        }
+
         params.fields = params.fields.join(",");
       } else {
         params.fields = "*.*";
       }
-
-      // ISSUE#1993 Preview Field URL Doesn't Contain Variable in List
-      const fieldValues = Object.values(this.fields);
-      var result = fieldValues.filter(field => field.type.toLowerCase() === "alias");
-      if (result.length > 0) params.fields = "*.*";
 
       if (this.searchQuery) {
         params.q = this.searchQuery;

--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -127,7 +127,7 @@
               <div
                 v-if="
                   (row[field] === '' || isNil(row[field])) &&
-                    fieldInfo.type.toLowerCase() != 'alias'
+                    (fieldInfo && fieldInfo.type.toLowerCase() != 'alias')
                 "
                 class="empty"
               >
@@ -135,7 +135,8 @@
               </div>
               <v-ext-display
                 v-else-if="
-                  useInterfaces && (!isNil(row[field]) || fieldInfo.type.toLowerCase() == 'alias')
+                  useInterfaces &&
+                    (!isNil(row[field]) || (fieldInfo && fieldInfo.type.toLowerCase() === 'alias'))
                 "
                 :id="field"
                 :interface-type="fieldInfo.interface"

--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -124,11 +124,19 @@
               }"
               class="cell"
             >
-              <div v-if="row[field] === '' || isNil(row[field])" class="empty">
+              <div
+                v-if="
+                  (row[field] === '' || isNil(row[field])) &&
+                    fieldInfo.type.toLowerCase() != 'alias'
+                "
+                class="empty"
+              >
                 --
               </div>
               <v-ext-display
-                v-else-if="useInterfaces && !isNil(row[field])"
+                v-else-if="
+                  useInterfaces && (!isNil(row[field]) || fieldInfo.type.toLowerCase() == 'alias')
+                "
                 :id="field"
                 :interface-type="fieldInfo.interface"
                 :name="field"

--- a/src/interfaces/many-to-many/input.vue
+++ b/src/interfaces/many-to-many/input.vue
@@ -53,6 +53,7 @@
                 :datatype="field.datatype"
                 :options="field.options"
                 :value="item[junctionRelatedKey][field.field]"
+                :values="item[junctionRelatedKey]"
               />
             </div>
             <button

--- a/src/interfaces/one-to-many/input.vue
+++ b/src/interfaces/one-to-many/input.vue
@@ -53,6 +53,7 @@
                 :datatype="field.datatype"
                 :options="field.options"
                 :value="String(item[field.field]).startsWith('$temp_') ? null : item[field.field]"
+                :values="item"
               />
             </div>
             <button

--- a/src/layouts/cards/layout.vue
+++ b/src/layouts/cards/layout.vue
@@ -42,6 +42,7 @@
             :type="fields[title].type"
             :options="fields[title].options"
             :value="item[title]"
+            :values="item"
             :relation="fields[title].relation"
           />
         </template>
@@ -54,6 +55,7 @@
             :type="fields[subtitle].type"
             :options="fields[subtitle].options"
             :value="item[subtitle]"
+            :values="item"
             :relation="fields[subtitle].relation"
           />
         </template>
@@ -66,6 +68,7 @@
             :type="fields[content].type"
             :options="fields[content].options"
             :value="item[content]"
+            :values="item"
             :relation="fields[content].relation"
           />
         </template>


### PR DESCRIPTION
In `Table Layout` and `Card layout`, when we select `Preview` interface it is showing -- in listing or card. Also in `M2M` and `O2M` mapping table listing when displaying `Preview` field, URL doesn't contain mentioned variable. This is fixed in this PR.