### PR TITLE
Fix #1766 [Visual glitches on table & error blocks]

### DIFF
--- a/src/components/error.vue
+++ b/src/components/error.vue
@@ -78,24 +78,7 @@ export default {
   }
 }
 
-.error-leave-active {
-  transition: var(--slow) var(--transition-in);
-
-  > * {
-    transition: var(--slow) var(--transition-in);
-
-    &:nth-child(1) {
-      transition-delay: 100ms;
-    }
-
-    &:nth-child(2) {
-      transition-delay: 50ms;
-    }
-  }
-}
-
-.error-enter,
-.error-leave-to {
+.error-enter {
   > * {
     opacity: 0;
     transform: translateY(15px);

--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -1,5 +1,11 @@
 <template>
-  <div ref="container" :style="{ minWidth: totalWidth + 'px' }" class="v-table" @scroll="onScroll">
+  <div
+    ref="container"
+    :style="{ minWidth: totalWidth + 'px' }"
+    class="v-table"
+    :class="{ loading }"
+    @scroll="onScroll"
+  >
     <div class="toolbar" :class="{ shadow: scrolled }">
       <div v-if="manualSortField" class="manual-sort cell" :class="{ active: manualSorting }">
         <button v-tooltip="$t('enable_manual_sorting')" @click="startManualSorting">
@@ -441,6 +447,13 @@ export default {
   position: relative;
   max-height: calc(100vh - var(--header-height));
   padding-bottom: var(--page-padding-bottom);
+  &.loading {
+    overflow: hidden; //Avoids scrollbars when initially loading items.
+    .body {
+      transition: opacity var(--medium) var(--transition-in);
+      opacity: 0.4;
+    }
+  }
 }
 
 .toolbar,
@@ -475,11 +488,6 @@ export default {
   height: calc(100% - var(--header-height));
   overflow: auto;
   -webkit-overflow-scrolling: touch;
-
-  &.loading {
-    transition: opacity var(--medium) var(--transition-in);
-    opacity: 0.4;
-  }
 }
 
 .drag-handle {


### PR DESCRIPTION
- Removed the exit animation for error component.
- The `loading` class moved to `v-table` instead of `body` to hide scrollbars when dummy rows are displayed.