### PR TITLE
Fix #2035[Custom status was not able to filtered]

### DIFF
--- a/src/components/form-inputs/toggle.vue
+++ b/src/components/form-inputs/toggle.vue
@@ -23,6 +23,10 @@ export default {
       default: null
     }
   },
+  created() {
+    // Emit input on created event to pass value to parent component
+    this.$emit("input", this.value);
+  },
   methods: {
     emitValue() {
       if (this.disabled) return;


### PR DESCRIPTION
The default value of boolean was not set for `Status` interface. That cause the issue for `API`. 
This PR will emit the value on the created event. 