### PR TITLE
Fix #2038 - Allow password managers to target field Id

### DIFF
--- a/src/routes/login.vue
+++ b/src/routes/login.vue
@@ -13,8 +13,10 @@
         <label class="project-switcher">
           <select
             v-if="Object.keys(urls).length > 1 || allowOther"
+            id="selectedUrl"
             v-model="selectedUrl"
             :disabled="loading"
+            name="selectedUrl"
           >
             <option
               v-for="(name, u) in urls"


### PR DESCRIPTION
Added attribute name and id to the select project dropdown so that password managers can target the field and fill it automatically.

Fixes #2038