### PR TITLE
Fixed typo in language files

### DIFF
--- a/src/lang/af-ZA/index.json
+++ b/src/lang/af-ZA/index.json
@@ -202,7 +202,7 @@
     "status": "System field used for publishing workflows",
     "string": "Any text, numbers, spaces, or symbols; defined and limited by its length (number of characters)",
     "time": "Time, eg: 14:09:22",
-    "translation": "Specific to translation interfaces, this o2m is stores multi-lingual content",
+    "translation": "Specific to translation interfaces, this o2m stores multi-lingual content",
     "user_created": "System field to track the user who created an item, used by revisions",
     "user_updated": "System field to track the user who updated an item, used by revisions",
     "uuid": "A Universally Unique Identifier"

--- a/src/lang/ar-SA/index.json
+++ b/src/lang/ar-SA/index.json
@@ -202,7 +202,7 @@
     "status": "System field used for publishing workflows",
     "string": "Any text, numbers, spaces, or symbols; defined and limited by its length (number of characters)",
     "time": "Time, eg: 14:09:22",
-    "translation": "Specific to translation interfaces, this o2m is stores multi-lingual content",
+    "translation": "Specific to translation interfaces, this o2m stores multi-lingual content",
     "user_created": "System field to track the user who created an item, used by revisions",
     "user_updated": "System field to track the user who updated an item, used by revisions",
     "uuid": "A Universally Unique Identifier"

--- a/src/lang/ca-ES/index.json
+++ b/src/lang/ca-ES/index.json
@@ -202,7 +202,7 @@
     "status": "System field used for publishing workflows",
     "string": "Any text, numbers, spaces, or symbols; defined and limited by its length (number of characters)",
     "time": "Time, eg: 14:09:22",
-    "translation": "Specific to translation interfaces, this o2m is stores multi-lingual content",
+    "translation": "Specific to translation interfaces, this o2m stores multi-lingual content",
     "user_created": "System field to track the user who created an item, used by revisions",
     "user_updated": "System field to track the user who updated an item, used by revisions",
     "uuid": "A Universally Unique Identifier"

--- a/src/lang/da-DK/index.json
+++ b/src/lang/da-DK/index.json
@@ -202,7 +202,7 @@
     "status": "System field used for publishing workflows",
     "string": "Any text, numbers, spaces, or symbols; defined and limited by its length (number of characters)",
     "time": "Time, eg: 14:09:22",
-    "translation": "Specific to translation interfaces, this o2m is stores multi-lingual content",
+    "translation": "Specific to translation interfaces, this o2m stores multi-lingual content",
     "user_created": "System field to track the user who created an item, used by revisions",
     "user_updated": "System field to track the user who updated an item, used by revisions",
     "uuid": "A Universally Unique Identifier"

--- a/src/lang/el-GR/index.json
+++ b/src/lang/el-GR/index.json
@@ -202,7 +202,7 @@
     "status": "System field used for publishing workflows",
     "string": "Any text, numbers, spaces, or symbols; defined and limited by its length (number of characters)",
     "time": "Time, eg: 14:09:22",
-    "translation": "Specific to translation interfaces, this o2m is stores multi-lingual content",
+    "translation": "Specific to translation interfaces, this o2m stores multi-lingual content",
     "user_created": "System field to track the user who created an item, used by revisions",
     "user_updated": "System field to track the user who updated an item, used by revisions",
     "uuid": "A Universally Unique Identifier"

--- a/src/lang/en-US/index.json
+++ b/src/lang/en-US/index.json
@@ -202,7 +202,7 @@
     "status": "System field used for publishing workflows",
     "string": "Any text, numbers, spaces, or symbols; defined and limited by its length (number of characters)",
     "time": "Time, eg: 14:09:22",
-    "translation": "Specific to translation interfaces, this o2m is stores multi-lingual content",
+    "translation": "Specific to translation interfaces, this o2m stores multi-lingual content",
     "user_created": "System field to track the user who created an item, used by revisions",
     "user_updated": "System field to track the user who updated an item, used by revisions",
     "uuid": "A Universally Unique Identifier"

--- a/src/lang/es-ES/index.json
+++ b/src/lang/es-ES/index.json
@@ -202,7 +202,7 @@
     "status": "System field used for publishing workflows",
     "string": "Any text, numbers, spaces, or symbols; defined and limited by its length (number of characters)",
     "time": "Time, eg: 14:09:22",
-    "translation": "Specific to translation interfaces, this o2m is stores multi-lingual content",
+    "translation": "Specific to translation interfaces, this o2m stores multi-lingual content",
     "user_created": "System field to track the user who created an item, used by revisions",
     "user_updated": "System field to track the user who updated an item, used by revisions",
     "uuid": "A Universally Unique Identifier"

--- a/src/lang/fi-FI/index.json
+++ b/src/lang/fi-FI/index.json
@@ -202,7 +202,7 @@
     "status": "System field used for publishing workflows",
     "string": "Any text, numbers, spaces, or symbols; defined and limited by its length (number of characters)",
     "time": "Time, eg: 14:09:22",
-    "translation": "Specific to translation interfaces, this o2m is stores multi-lingual content",
+    "translation": "Specific to translation interfaces, this o2m stores multi-lingual content",
     "user_created": "System field to track the user who created an item, used by revisions",
     "user_updated": "System field to track the user who updated an item, used by revisions",
     "uuid": "A Universally Unique Identifier"

--- a/src/lang/he-IL/index.json
+++ b/src/lang/he-IL/index.json
@@ -202,7 +202,7 @@
     "status": "System field used for publishing workflows",
     "string": "Any text, numbers, spaces, or symbols; defined and limited by its length (number of characters)",
     "time": "Time, eg: 14:09:22",
-    "translation": "Specific to translation interfaces, this o2m is stores multi-lingual content",
+    "translation": "Specific to translation interfaces, this o2m stores multi-lingual content",
     "user_created": "System field to track the user who created an item, used by revisions",
     "user_updated": "System field to track the user who updated an item, used by revisions",
     "uuid": "A Universally Unique Identifier"

--- a/src/lang/hu-HU/index.json
+++ b/src/lang/hu-HU/index.json
@@ -202,7 +202,7 @@
     "status": "System field used for publishing workflows",
     "string": "Any text, numbers, spaces, or symbols; defined and limited by its length (number of characters)",
     "time": "Time, eg: 14:09:22",
-    "translation": "Specific to translation interfaces, this o2m is stores multi-lingual content",
+    "translation": "Specific to translation interfaces, this o2m stores multi-lingual content",
     "user_created": "System field to track the user who created an item, used by revisions",
     "user_updated": "System field to track the user who updated an item, used by revisions",
     "uuid": "A Universally Unique Identifier"

--- a/src/lang/ja-JP/index.json
+++ b/src/lang/ja-JP/index.json
@@ -202,7 +202,7 @@
     "status": "System field used for publishing workflows",
     "string": "Any text, numbers, spaces, or symbols; defined and limited by its length (number of characters)",
     "time": "Time, eg: 14:09:22",
-    "translation": "Specific to translation interfaces, this o2m is stores multi-lingual content",
+    "translation": "Specific to translation interfaces, this o2m stores multi-lingual content",
     "user_created": "System field to track the user who created an item, used by revisions",
     "user_updated": "System field to track the user who updated an item, used by revisions",
     "uuid": "A Universally Unique Identifier"

--- a/src/lang/ko-KR/index.json
+++ b/src/lang/ko-KR/index.json
@@ -202,7 +202,7 @@
     "status": "System field used for publishing workflows",
     "string": "Any text, numbers, spaces, or symbols; defined and limited by its length (number of characters)",
     "time": "Time, eg: 14:09:22",
-    "translation": "Specific to translation interfaces, this o2m is stores multi-lingual content",
+    "translation": "Specific to translation interfaces, this o2m stores multi-lingual content",
     "user_created": "System field to track the user who created an item, used by revisions",
     "user_updated": "System field to track the user who updated an item, used by revisions",
     "uuid": "A Universally Unique Identifier"

--- a/src/lang/pt-PT/index.json
+++ b/src/lang/pt-PT/index.json
@@ -202,7 +202,7 @@
     "status": "System field used for publishing workflows",
     "string": "Any text, numbers, spaces, or symbols; defined and limited by its length (number of characters)",
     "time": "Time, eg: 14:09:22",
-    "translation": "Specific to translation interfaces, this o2m is stores multi-lingual content",
+    "translation": "Specific to translation interfaces, this o2m stores multi-lingual content",
     "user_created": "System field to track the user who created an item, used by revisions",
     "user_updated": "System field to track the user who updated an item, used by revisions",
     "uuid": "A Universally Unique Identifier"

--- a/src/lang/ro-RO/index.json
+++ b/src/lang/ro-RO/index.json
@@ -202,7 +202,7 @@
     "status": "System field used for publishing workflows",
     "string": "Any text, numbers, spaces, or symbols; defined and limited by its length (number of characters)",
     "time": "Time, eg: 14:09:22",
-    "translation": "Specific to translation interfaces, this o2m is stores multi-lingual content",
+    "translation": "Specific to translation interfaces, this o2m stores multi-lingual content",
     "user_created": "System field to track the user who created an item, used by revisions",
     "user_updated": "System field to track the user who updated an item, used by revisions",
     "uuid": "A Universally Unique Identifier"

--- a/src/lang/sr-SP/index.json
+++ b/src/lang/sr-SP/index.json
@@ -202,7 +202,7 @@
     "status": "System field used for publishing workflows",
     "string": "Any text, numbers, spaces, or symbols; defined and limited by its length (number of characters)",
     "time": "Time, eg: 14:09:22",
-    "translation": "Specific to translation interfaces, this o2m is stores multi-lingual content",
+    "translation": "Specific to translation interfaces, this o2m stores multi-lingual content",
     "user_created": "System field to track the user who created an item, used by revisions",
     "user_updated": "System field to track the user who updated an item, used by revisions",
     "uuid": "A Universally Unique Identifier"

--- a/src/lang/sv-SE/index.json
+++ b/src/lang/sv-SE/index.json
@@ -202,7 +202,7 @@
     "status": "System field used for publishing workflows",
     "string": "Any text, numbers, spaces, or symbols; defined and limited by its length (number of characters)",
     "time": "Time, eg: 14:09:22",
-    "translation": "Specific to translation interfaces, this o2m is stores multi-lingual content",
+    "translation": "Specific to translation interfaces, this o2m stores multi-lingual content",
     "user_created": "System field to track the user who created an item, used by revisions",
     "user_updated": "System field to track the user who updated an item, used by revisions",
     "uuid": "A Universally Unique Identifier"

--- a/src/lang/uk-UA/index.json
+++ b/src/lang/uk-UA/index.json
@@ -202,7 +202,7 @@
     "status": "System field used for publishing workflows",
     "string": "Any text, numbers, spaces, or symbols; defined and limited by its length (number of characters)",
     "time": "Time, eg: 14:09:22",
-    "translation": "Specific to translation interfaces, this o2m is stores multi-lingual content",
+    "translation": "Specific to translation interfaces, this o2m stores multi-lingual content",
     "user_created": "System field to track the user who created an item, used by revisions",
     "user_updated": "System field to track the user who updated an item, used by revisions",
     "uuid": "A Universally Unique Identifier"

--- a/src/lang/vi-VN/index.json
+++ b/src/lang/vi-VN/index.json
@@ -202,7 +202,7 @@
     "status": "System field used for publishing workflows",
     "string": "Any text, numbers, spaces, or symbols; defined and limited by its length (number of characters)",
     "time": "Time, eg: 14:09:22",
-    "translation": "Specific to translation interfaces, this o2m is stores multi-lingual content",
+    "translation": "Specific to translation interfaces, this o2m stores multi-lingual content",
     "user_created": "System field to track the user who created an item, used by revisions",
     "user_updated": "System field to track the user who updated an item, used by revisions",
     "uuid": "A Universally Unique Identifier"

--- a/src/lang/zh-TW/index.json
+++ b/src/lang/zh-TW/index.json
@@ -202,7 +202,7 @@
     "status": "System field used for publishing workflows",
     "string": "Any text, numbers, spaces, or symbols; defined and limited by its length (number of characters)",
     "time": "時間，例如: 14:09:22",
-    "translation": "Specific to translation interfaces, this o2m is stores multi-lingual content",
+    "translation": "Specific to translation interfaces, this o2m stores multi-lingual content",
     "user_created": "記錄新增項目的使用者的系統欄位，用於版本",
     "user_updated": "記錄更新項目的使用者的系統欄位，用於版本",
     "uuid": "A Universally Unique Identifier"

--- a/src/routes/login.vue
+++ b/src/routes/login.vue
@@ -13,8 +13,10 @@
         <label class="project-switcher">
           <select
             v-if="Object.keys(urls).length > 1 || allowOther"
+            id="selectedUrl"
             v-model="selectedUrl"
             :disabled="loading"
+            name="selectedUrl"
           >
             <option
               v-for="(name, u) in urls"


### PR DESCRIPTION
Removed _is_ from 'Specific to translation interfaces, this o2m **is** stores multi-lingual content'