### PR TITLE
Adds a button to quick navigate to collection settings

### DIFF
--- a/src/routes/items.vue
+++ b/src/routes/items.vue
@@ -17,14 +17,6 @@
         >
           <v-icon :name="currentBookmark ? 'bookmark' : 'bookmark_border'" />
         </button>
-
-        <button
-          v-if="this.$store.state.currentUser.admin"
-          class="settings"
-          @click="editCollection()"
-        >
-          <v-icon :name="'settings_application'" />
-        </button>
       </template>
       <v-search-filter
         v-show="selection && selection.length === 0 && !emptyCollection"
@@ -37,6 +29,14 @@
         @clear-filters="clearFilters"
       />
       <template slot="buttons">
+        <v-header-button
+          v-if="this.$store.state.currentUser.admin"
+          :label="$t('settings')"
+          icon="settings"
+          icon-color="lighter_gray"
+          no-background
+          @click="editCollection()"
+        />
         <v-header-button
           v-if="editButton && !activity"
           key="edit"

--- a/src/routes/items.vue
+++ b/src/routes/items.vue
@@ -17,6 +17,14 @@
         >
           <v-icon :name="currentBookmark ? 'bookmark' : 'bookmark_border'" />
         </button>
+
+        <button
+          v-if="this.$store.state.currentUser.admin"
+          class="settings"
+          @click="editCollection()"
+        >
+          <v-icon :name="'settings_application'" />
+        </button>
       </template>
       <v-search-filter
         v-show="selection && selection.length === 0 && !emptyCollection"
@@ -494,6 +502,10 @@ export default {
   },
   methods: {
     keyBy: _.keyBy,
+    editCollection() {
+      if (!this.$store.state.currentUser.admin) return;
+      this.$router.push(`/settings/collections/${this.collection}`);
+    },
     closeBookmark() {
       this.bookmarkModal = false;
     },
@@ -694,7 +706,8 @@ label.style-4 {
   padding-bottom: 5px;
 }
 
-.bookmark {
+.bookmark,
+.settings {
   margin-left: 5px;
   position: relative;
 


### PR DESCRIPTION
This is just a suggestion from something that really annoyed me when working all day long on collection setup. It's just displayed when currentUser has admin

This adds a small button on items to quickly navigate to collection settings instead of having to do big navigations to edit a collection fields:

- menu (please see #2050 too)
- admin settings 
- collections 
- collection

![image](https://user-images.githubusercontent.com/412397/64916171-e6bbd080-d74e-11e9-9135-31f52b62a082.png)

goes to 

![image](https://user-images.githubusercontent.com/412397/64916176-f63b1980-d74e-11e9-9261-ea1308d1cae8.png)

