### PR TITLE
pass through all translations data on child collection

### DIFF
--- a/src/interfaces/one-to-many/input.vue
+++ b/src/interfaces/one-to-many/input.vue
@@ -453,7 +453,7 @@ export default {
 
               const type = fieldInfo.type.toLowerCase();
 
-              if (type === "json") {
+              if (type === "json" || type === "translation") {
                 delta[key] = after[key];
               }
             });


### PR DESCRIPTION
I am still testing this, and it might not work in all situations and preferably I would only add the primary key of all the updated translations to the diff of the translation instead of adding the whole payload. But I am not sure if this is possible and worth it. (I haven't checked yet)