### PR TITLE
add gitpod.io support for App

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,12 @@
+tasks:
+  - command: clear
+  - init: npm install 
+    command: npm run dev
+
+ports:
+  - port: 8080
+    onOpen: open-preview
+
+vscode:
+  extensions:
+    - jcbuisson.vue@0.1.5:iY3UUCX2mmoIw5ODWkEcyw==

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ We love pull-requests! To work on Directus you'll need to install it locally fro
 * [Setup API Development Environment](https://docs.directus.io/advanced/source.html#api-source)
 * [Setup App Development Environment](https://docs.directus.io/advanced/source.html#application-source)
 
+For working on the App you can also use a one-click browser based dev environment:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/directus/app)
+
 ### Sponsors
 
 [RANGER Studio](http://rangerstudio.com), Bas Jansen

--- a/vue.config.js
+++ b/vue.config.js
@@ -2,6 +2,10 @@ module.exports = {
   lintOnSave: false,
   publicPath: process.env.NODE_ENV === "production" ? "" : "/",
 
+  devServer: {
+    allowedHosts: ['localhost', '.gitpod.io'],
+  },
+  
   // There are so many chunks (from all the interfaces / layouts) that we need to make sure to not
   // prefetch them all. Prefetching them all will cause the server to apply rate limits in most cases
   chainWebpack: config => {


### PR DESCRIPTION
I added basic gitpod.io support for the directus/app repository. Now we can spin up a browser based development environment with just one click! Contributing to the code is now only one click away.

Try it yourself on my repository: https://gitpod.io/#https://github.com/PostPollux/app/tree/gitpod_support

