### PR TITLE
Enable/make the drag event to be triggered in the Firefox browser

### DIFF
--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -385,6 +385,7 @@ export default {
       img.src = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
       event.dataTransfer.setDragImage(img, 0, 0);
       event.dataTransfer.effectAllowed = "move";
+      event.dataTransfer.setData("text/plain", null); //Just to enable/make the drag event to be triggered in the Firefox browser
     },
     initWidths() {
       const widths = {};


### PR DESCRIPTION
@rijkvanzanten, this is a partial fix to make drag event gets fired in firefox browser. Still there is an issue with few firefox browser versions as screenX/screenY coming 0 in drag events.

https://bugzilla.mozilla.org/show_bug.cgi?id=1428225
https://bugzilla.mozilla.org/show_bug.cgi?id=1588299

Related: #2090

@benhaynes 