### PR TITLE
Fix #2184 [ Users are not shown on the role's page ]

### DIFF
--- a/src/routes/settings/permissions.vue
+++ b/src/routes/settings/permissions.vue
@@ -261,8 +261,11 @@ export default {
           });
         });
     }
+    const params = {
+      fields: "*.*.*"
+    };
 
-    return Promise.all([api.getRole(+id), api.getFields("directus_roles")])
+    return Promise.all([api.getRole(+id, params), api.getFields("directus_roles")])
       .then(([roleRes, fieldsRes]) => ({
         role: roleRes.data,
         fields: keyBy(


### PR DESCRIPTION
I want to mention one thing here. Users are not shown on the role's page is solved with this PR. But when clicking on that user, the edit model is not opening so we can't edit that particular user. The reason behind this is that from APP get Item is called with collection `directus_user_roles` and user PK but don't know why it is calling `user_roles` API endpoint and I think there is no endpoint available in API.

