### PR TITLE
Fix status when batch editing collections

### DIFF
--- a/src/interfaces/status/input.vue
+++ b/src/interfaces/status/input.vue
@@ -42,7 +42,7 @@ export default {
       const blacklist = this.blacklist;
 
       _.forEach(allStatuses, function(value) {
-        if (blacklist.includes(value.value)) {
+        if (_.includes(blacklist, value.value)) {
           value.readonly = true;
         }
       });


### PR DESCRIPTION
Solve #2309, When there is not blacklist (undefined) the native includes function throw an error and the status is not displayed, fixed using lodash includes.