### PR TITLE
#1922 checkboxes-relational: Create / Update Sends only referenced PKs

### DIFF
--- a/src/interfaces/checkboxes-relational/input.vue
+++ b/src/interfaces/checkboxes-relational/input.vue
@@ -97,7 +97,7 @@ export default {
     },
 
     prepareItem(item) {
-      return { [this.junctionFieldOfRelated]: item };
+      return { [this.junctionFieldOfRelated]: { [this.relatedPk]: item[this.relatedPk] } };
     },
 
     /**


### PR DESCRIPTION
Checkboxes-relational does not have possibility to edit/modify referenced
item, so sending only IDs is sufficient.

Sending only primary keys instead of whole item:
  - fixes unnecessary updates of referenced items
    - this fixes possible bug, if referenced item was updated in other
      window during selection
    - performance issues related to unnecessary updates #1922
  - allows for having group which can modify checkboxes, but is not
    allowed to modify referenced item.