### PR TITLE
Rework translations interface

### DIFF
--- a/src/interfaces/key-value/meta.json
+++ b/src/interfaces/key-value/meta.json
@@ -15,6 +15,7 @@
     "keyType": {
       "name": "$t:key_data_type",
       "interface": "interface-types",
+      "default": "string",
       "options": {
         "interfaceField": "keyInterface"
       }
@@ -22,6 +23,9 @@
     "keyOptions": {
       "name": "$t:key_options",
       "interface": "interface-options",
+      "default": {
+        "placeholder": "Key"
+      },
       "options": {
         "interfaceField": "keyInterface"
       }
@@ -37,6 +41,7 @@
     "valueType": {
       "name": "$t:value_data_type",
       "interface": "interface-types",
+      "default": "string",
       "options": {
         "interfaceField": "valueInterface"
       }
@@ -44,6 +49,9 @@
     "valueOptions": {
       "name": "$t:value_options",
       "interface": "interface-options",
+      "default": {
+        "placeholder": "Value"
+      },
       "options": {
         "interfaceField": "valueInterface"
       }

--- a/src/interfaces/translation/display.vue
+++ b/src/interfaces/translation/display.vue
@@ -1,13 +1,54 @@
 <template>
-  <div class="display-translation">
-    {{ $tc("item_count", (value || []).length, { count: (value || []).length }) }}
-  </div>
+  <span :class="{ empty: !displayValue }">
+    {{ displayValue }}
+    <template v-if="!displayValue">
+      {{ $t("not_translated_in_language", { language: systemLanguagePrinted }) }}
+    </template>
+  </span>
 </template>
 
 <script>
 import mixin from "@directus/extension-toolkit/mixins/interface";
 
 export default {
-  mixins: [mixin]
+  mixins: [mixin],
+  computed: {
+    systemLanguage() {
+      return this.$i18n.locale;
+    },
+    systemLanguagePrinted() {
+      return this.$i18n.availableLanguages[this.systemLanguage].split("(")[0];
+    },
+    systemLanguageValues() {
+      const { languageField } = this.options;
+      const fullMatch = _.find(this.value, { [languageField]: this.systemLanguage });
+      const partialMatch = _.find(this.value, {
+        [languageField]: this.systemLanguage.split("-")[0]
+      });
+
+      return fullMatch || partialMatch;
+    },
+    displayValue() {
+      if (!this.value || this.value.length === 0) {
+        return null;
+      }
+
+      if (!this.options.template) {
+        return this.$tc("item_count", (this.value || []).length);
+      }
+
+      if (this.systemLanguageValues) {
+        return this.$helpers.micromustache.render(this.options.template, this.systemLanguageValues);
+      }
+
+      return null;
+    }
+  }
 };
 </script>
+
+<style lang="scss">
+.empty {
+  color: var(--empty-value);
+}
+</style>

--- a/src/interfaces/translation/input.vue
+++ b/src/interfaces/translation/input.vue
@@ -11,6 +11,7 @@
 
     <div v-if="loading === false && initialValues !== null" class="body">
       <v-form
+        :key="currentLanguage"
         full-width
         :fields="translatedFields"
         :values="currentLanguageValues"

--- a/src/interfaces/translation/input.vue
+++ b/src/interfaces/translation/input.vue
@@ -149,7 +149,7 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 .language-picker {
   margin-bottom: 24px;
 }

--- a/src/interfaces/translation/input.vue
+++ b/src/interfaces/translation/input.vue
@@ -1,40 +1,29 @@
 <template>
-  <div v-if="error || !relation" class="translation error">
-    <p>
-      <v-icon name="warning" />
-      {{ $t("interfaces.translation.translation_not_setup") }}
-    </p>
-  </div>
-  <div v-else-if="!languages || languages.length === 0" class="translation error">
-    <p>
-      <v-icon name="warning" />
-      {{ $t("interfaces.translation.translation_no_languages") }}
-    </p>
-  </div>
-  <div v-else-if="activeLanguage != null" class="translation">
-    <v-simple-select
-      v-model="activeLanguage"
-      class="language-select"
-      :placeholder="$t('interfaces.translation.choose_language')"
-    >
-      <option v-for="language in languages" :key="language.code" :value="language.code">
-        {{ language.name }}
-      </option>
-    </v-simple-select>
+  <v-sheet v-if="relationshipSetup">
+    <v-select
+      v-model="currentLanguage"
+      class="language-picker"
+      :options="options.languages"
+      icon="translate"
+    />
 
     <hr />
 
-    <v-form
-      :key="activeLanguage"
-      ref="form"
-      class="form"
-      :fields="relatedFields"
-      :values="langValue"
-      :collection="relation.collection_many.collection"
-      :new-item="isNew"
-      @stage-value="stageValue"
-    />
-  </div>
+    <div v-if="loading === false && initialValues !== null" class="body">
+      <v-form
+        full-width
+        :fields="translatedFields"
+        :values="currentLanguageValues"
+        @stage-value="saveLanguage"
+      />
+    </div>
+
+    <v-spinner v-else />
+  </v-sheet>
+
+  <v-notice v-else color="warning" icon="warning">
+    {{ $t("relationship_not_setup") }}
+  </v-notice>
 </template>
 
 <script>
@@ -44,184 +33,140 @@ export default {
   mixins: [mixin],
   data() {
     return {
-      activeLanguage: null,
-      languages: null
+      currentLanguage: Object.keys(this.options.languages)[0],
+      loading: false,
+      initialValues: null,
+      relationalChanges: []
     };
   },
   computed: {
-    error() {
-      if (!this.options.languagesCollection || !this.options.translationLanguageField) return true;
-      return false;
-    },
-    primaryKeyField() {
-      return _.find(this.fields, { primary_key: true }).field;
-    },
-    primaryKey() {
-      return this.values[this.primaryKeyField];
-    },
-    relatedFields() {
-      if (!this.relation) return null;
-      return this.relation.collection_many.fields;
-    },
-    languageFields() {
-      if (!this.options.languagesCollection) return null;
-      return this.$store.state.collections[this.options.languagesCollection].fields;
-    },
-    langValue() {
-      if (!this.languages || !this.activeLanguage) return {};
-      if (!this.value) return {};
+    translatedFields() {
+      if (this.relationshipSetup === false) {
+        return;
+      }
 
-      return this.valuesByLang[this.activeLanguage] || {};
-    },
-    isNew() {
-      return this.valuesByLang[this.activeLanguage] !== undefined;
-    },
-    valuesByLang() {
-      if (!this.value) return {};
+      return _.mapValues(this.relation.collection_many.fields, field => {
+        field = _.clone(field); // remove vue reactivity
 
-      let firstKey = this.options.translationLanguageField;
-      let secondKey = this.options.languagesPrimaryKeyField;
-      return _(this.value)
-        .map(v => {
-          v[firstKey] = v[firstKey][secondKey] || v[firstKey];
-          return v;
-        })
-        .keyBy(this.options.translationLanguageField)
-        .value();
+        // Prevent updating the recursive relational key
+        if (field.field === this.relation.field_many.field) {
+          field.readonly = true;
+        }
+
+        return field;
+      });
     },
-    fieldManyName() {
-      return this.relation.field_many.field;
+    defaults() {
+      return _.mapValues(_.clone(this.translatedFields), f => f.default_value);
+    },
+    existing() {
+      return _.find(this.initialValues, { [this.options.languageField]: this.currentLanguage });
+    },
+    currentLanguageValues() {
+      const existingChanges = _.find(this.relationalChanges, {
+        [this.options.languageField]: this.currentLanguage
+      });
+
+      return _.merge({}, this.existing || this.defaults, existingChanges);
+    },
+    relationshipSetup() {
+      return !!this.relation?.collection_many;
+    },
+    currentPrimaryKey() {
+      const { field } = _.find(this.fields, { primary_key: true });
+      return this.values[field];
+    }
+  },
+  watch: {
+    relationalChanges: {
+      deep: true,
+      handler(value) {
+        if (value) {
+          this.$emit("input", value);
+        }
+      }
     }
   },
   created() {
-    this.fetchLanguages();
+    this.fetchInitial();
   },
   methods: {
-    fetchLanguages() {
-      if (!this.options.languagesCollection || !this.options.translationLanguageField) return null;
-      this.$api
-        .getItems(this.options.languagesCollection, { limit: -1 })
-        .then(res => res.data)
-        .then(languages => {
-          if (languages.length === 0) return;
-
-          const primaryKeyField = this.options.languagesPrimaryKeyField;
-          const nameField = this.options.languagesNameField;
-
-          this.languages = languages.map(language => {
-            return {
-              code: language[primaryKeyField],
-              name: language[nameField]
-            };
-          });
-          /*
-            When no default translation language is selected,display the placeholder and
-            when updating item if translation is added, display it otherwise display
-            the placeholder.
-            Fix 2099
-          */
-          if (this.values.translation == null) {
-            this.activeLanguage = this.options.defaultLanguage ? this.options.defaultLanguage : 0;
-          } else {
-            this.activeLanguage =
-              languages[0][
-                _.find(this.languageFields, {
-                  primary_key: true
-                }).field
-              ];
-          }
-        });
-    },
-    stageValue({ field, value }) {
-      let newValue;
-
-      if (!this.valuesByLang[this.activeLanguage]) {
-        newValue = this.newItem
-          ? [
-              ...(this.value || []),
-              {
-                [this.options.translationLanguageField]: this.activeLanguage,
-                [field]: value
-              }
-            ]
-          : [
-              ...(this.value || []),
-              {
-                [this.relation.field_many.field]: this.primaryKey,
-                [this.options.translationLanguageField]: this.activeLanguage,
-                [field]: value
-              }
-            ];
-      } else {
-        newValue = this.value.map(translation => {
-          let language = translation[this.options.translationLanguageField];
-          if (
-            language == this.activeLanguage ||
-            language[this.options.languagesPrimaryKeyField] == this.activeLanguage
-          ) {
-            return {
-              ...translation,
-              [field]: value
-            };
-          }
-
-          return translation;
-        });
-      }
-
-      newValue = newValue.map(values => {
-        const valuesCopy = Object.assign({}, values);
-        delete valuesCopy[this.fieldManyName];
-        return valuesCopy;
+    saveLanguage({ field, value }) {
+      const existingChanges = _.find(this.relationalChanges, {
+        [this.options.languageField]: this.currentLanguage
       });
 
-      return this.$emit("input", newValue);
+      if (existingChanges) {
+        this.relationalChanges = this.relationalChanges.map(update => {
+          if (update[this.options.languageField] === this.currentLanguage) {
+            return _.merge({}, update, { [field]: value });
+          }
+
+          return update;
+        });
+      } else {
+        const update = {
+          [field]: value,
+          [this.options.languageField]: this.currentLanguage
+        };
+
+        if (this.existing) {
+          const primaryKeyField = _.find(this.translatedFields, { primary_key: true }).field;
+          const relatedPrimaryKey = this.existing[primaryKeyField];
+          update[primaryKeyField] = relatedPrimaryKey;
+        }
+
+        this.relationalChanges = [...this.relationalChanges, update];
+      }
+    },
+    async fetchInitial() {
+      if (this.relationshipSetup === false) {
+        return;
+      }
+
+      if (this.newItem) {
+        this.initialValues = [];
+        return;
+      }
+
+      this.loading = true;
+      const { collection } = this.relation.collection_many;
+      const { field } = this.relation.field_many;
+
+      const { data } = await this.$api.getItems(collection, {
+        filter: {
+          [field]: {
+            eq: this.currentPrimaryKey
+          }
+        }
+      });
+
+      this.initialValues = data;
+      this.loading = false;
     }
   }
 };
 </script>
 
-<style lang="scss" scoped>
-.translation {
-  width: 100%;
-  padding: var(--page-padding);
-  border: var(--input-border-width) solid var(--input-border-color);
-  border-radius: var(--border-radius);
-
-  &.disabled {
-    position: relative;
-
-    .language-select,
-    hr,
-    .form {
-      user-select: none;
-      pointer-events: none;
-      opacity: 0.2;
-    }
-
-    p {
-      top: 0;
-      left: 0;
-      position: absolute;
-      width: 100%;
-      height: 100%;
-      text-align: center;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-    }
-  }
+<style lang="scss">
+.language-picker {
+  margin-bottom: 24px;
 }
 
 hr {
-  margin: 20px 0;
-  border: 0;
-  border-bottom: 1px dashed var(--blue-grey-200);
+  border: none;
+  border-bottom: 2px solid var(--input-border-color);
+  border-radius: 1px;
+  margin-bottom: 24px;
 }
 
-.form {
-  grid-template-columns:
-    [start] minmax(0, var(--form-column-width)) [half] minmax(0, var(--form-column-width))
-    [full];
+.body {
+  --form-vertical-gap: 24px;
+  --form-horizontal-gap: 12px;
+  --type-label-size: 15px;
+  --input-height: 44px;
+  --input-font-size: 14px;
+  --input-label-margin: 4px;
+  --input-background-color-alt: var(--input-background-color);
 }
 </style>

--- a/src/interfaces/translation/meta.json
+++ b/src/interfaces/translation/meta.json
@@ -5,46 +5,24 @@
   "relation": "o2m",
   "icon": "translate",
   "options": {
-    "languagesCollection": {
-      "name": "$t:languages_collection",
-      "comment": "$t:languages_collection_comment",
-      "interface": "collections",
-      "required": true
-    },
-    "languagesPrimaryKeyField": {
-      "name": "$t:languages_primary",
-      "comment": "$t:languages_primary_comment",
+    "languageField": {
+      "name": "$t:language_field",
+      "comment": "$t:language_field_comment",
       "interface": "text-input",
-      "required": true,
       "options": {
-        "placeholder": "code"
+        "monospace": true
       }
     },
-    "languagesNameField": {
-      "name": "$t:languages_name",
-      "comment": "$t:languages_name_comment",
-      "interface": "text-input",
-      "required": true,
+    "languages": {
+      "name": "$t:languages",
+      "interface": "key-value",
       "options": {
-        "placeholder": "name"
-      }
-    },
-    "translationLanguageField": {
-      "name": "$t:translation_language",
-      "comment": "$t:translation_language_comment",
-      "interface": "text-input",
-      "required": true,
-      "options": {
-        "placeholder": "language_code"
-      }
-    },
-    "defaultLanguage": {
-      "name": "$t:default_language",
-      "comment": "$t:default_language_comment",
-      "interface": "text-input",
-      "required": true,
-      "options": {
-        "placeholder": "nl-NL"
+        "keyOptions": {
+          "placeholder": "Code (en-US)"
+        },
+        "valueOptions": {
+          "placeholder": "Name (English)"
+        }
       }
     }
   }

--- a/src/interfaces/translation/meta.json
+++ b/src/interfaces/translation/meta.json
@@ -16,9 +16,19 @@
     "languages": {
       "name": "$t:languages",
       "interface": "key-value",
+      "default": {
+        "en": "English",
+        "es": "Spanish",
+        "de": "German",
+        "fr": "French",
+        "pt": "Portuguese",
+        "zh": "Chinese",
+        "ru": "Russian"
+      },
       "options": {
         "keyOptions": {
-          "placeholder": "Code (en-US)"
+          "placeholder": "Code (en-US)",
+          "monospace": true
         },
         "valueOptions": {
           "placeholder": "Name (English)"

--- a/src/interfaces/translation/meta.json
+++ b/src/interfaces/translation/meta.json
@@ -24,6 +24,14 @@
           "placeholder": "Name (English)"
         }
       }
+    },
+    "template": {
+      "name": "$t:template",
+      "comment": "$t:template_comment",
+      "interface": "text-input",
+      "options": {
+        "placeholder": "$t:template_placeholder"
+      }
     }
   }
 }

--- a/src/interfaces/wysiwyg/meta.json
+++ b/src/interfaces/wysiwyg/meta.json
@@ -9,7 +9,7 @@
   "options": {
     "toolbar": {
       "name": "$t:toolbar",
-      "comment": "$t:toolbar_options",
+      "comment": "$t:toolbar_comment",
       "interface": "checkboxes",
       "default": [
         "bold",

--- a/src/lang/en-US/index.json
+++ b/src/lang/en-US/index.json
@@ -504,6 +504,7 @@
   "text": "Text",
   "translation": "Translation",
   "translated_field_name": "Translated field name...",
+  "not_translated_in_language": "Not Translated in {language}",
   "this_item_is_not_available": "This item is not available.",
   "this_collection": "This Collection",
   "to": "To",

--- a/src/lang/en-US/interfaces.json
+++ b/src/lang/en-US/interfaces.json
@@ -579,19 +579,9 @@
     },
     "translation": {
       "translation": "Translation",
-      "languages_collection": "Languages Collection",
-      "languages_collection_comment": "Collection that stores the language options",
-      "languages_primary": "Languages Primary Key Field",
-      "languages_primary_comment": "Field that holds the language primary key on the languages collection",
-      "languages_name": "Languages Name Field",
-      "languages_name_comment": "Field that holds the language's name on the languages collection",
-      "translation_language": "Translation Language Field",
-      "translation_language_comment": "The field that stores the language primary key in the related translations collection",
-      "translation_not_setup": "Interface not configured correctly",
-      "translation_no_languages": "There are no languages in the languages collection",
-      "default_language": "Default Language",
-      "default_language_comment": "Add the primary key of the item in the languages collection to use as the default language",
-      "choose_language": "Choose Language..."
+      "language_field": "Language Field",
+      "language_field_comment": "The field that holds the language code in the related collection",
+      "languages": "Languages"
     },
     "user": {
       "user": "User",

--- a/src/lang/en-US/interfaces.json
+++ b/src/lang/en-US/interfaces.json
@@ -584,7 +584,7 @@
       "languages": "Languages",
       "template": "Display Template",
       "template_comment": "Choose how to display values on the item layouts",
-      "template_placeholder": "{{movie.name}} — {{member.first_name}}"
+      "template_placeholder": "{{title}} — {{body}}"
     },
     "user": {
       "user": "User",

--- a/src/lang/en-US/interfaces.json
+++ b/src/lang/en-US/interfaces.json
@@ -581,7 +581,10 @@
       "translation": "Translation",
       "language_field": "Language Field",
       "language_field_comment": "The field that holds the language code in the related collection",
-      "languages": "Languages"
+      "languages": "Languages",
+      "template": "Display Template",
+      "template_comment": "Choose how to display values on the item layouts",
+      "template_placeholder": "{{movie.name}} — {{member.first_name}}"
     },
     "user": {
       "user": "User",


### PR DESCRIPTION
* No longer requires a separate collection for languages
* Design matches other interfaces and 'v8' style better
* Fixed state issues when switching languages
* Display component now has the ability to show you a translation preview based on a template string (like m2o)
* The template string will be rendered in the users language

Fixes #2329, fixes #2275, fixes #2221 
Implements #2337

![image](https://user-images.githubusercontent.com/9141017/70834273-dfe14000-1dc7-11ea-8a3d-f9aebd0d208e.png)

![image](https://user-images.githubusercontent.com/9141017/70834520-90e7da80-1dc8-11ea-8d07-5d5161dc28b2.png)
