### PR TITLE
fix #2366 correct singleItem collection title translation when editing

### DIFF
--- a/src/routes/item.vue
+++ b/src/routes/item.vue
@@ -381,7 +381,7 @@ export default {
           },
           {
             name: this.$t("editing_single", {
-              collection: this.$helpers.formatTitle(this.collection)
+              collection: this.$helpers.formatCollection(this.collection)
             }),
             path: this.$route.path
           }


### PR DESCRIPTION
Fix #2366 

When edit a singleItem collection, the title translation of collection name is broken.