### PR TITLE
Add readonly status to user-roles input

### DIFF
--- a/src/interfaces/user-roles/input.vue
+++ b/src/interfaces/user-roles/input.vue
@@ -6,6 +6,7 @@
 		:placeholder="$t('interfaces.user-roles.choose_role')"
 		:options="selectOptions"
 		:value="primaryKey"
+		:disabled="readonly"
 		@input="emitValue"
 	></v-select>
 </template>


### PR DESCRIPTION
When you disable role edit permissions to a user role, that user still can edit its own role. What is a great security issue.
This happens because the user-roles input is not disabled when set to readonly.
This change fix it.