### PR TITLE
Contextual Menu with Header Button Positioning Issue

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
-  "htmlWhitespaceSensitivity": "ignore",
-  "printWidth": 100,
-  "singleQuote": true
+	"htmlWhitespaceSensitivity": "ignore",
+	"printWidth": 100,
+	"singleQuote": true,
+	"useTabs": true
 }

--- a/src/components/contextual-menu.vue
+++ b/src/components/contextual-menu.vue
@@ -104,7 +104,7 @@ export default {
 	li {
 		display: block;
 	}
-	i {
+	.v-icon {
 		color: var(--popover-text-color);
 		margin-right: 8px;
 		transition: color var(--fast) var(--transition);

--- a/src/components/header/header-button.vue
+++ b/src/components/header/header-button.vue
@@ -9,7 +9,7 @@
 		<v-contextual-menu
 			v-if="Object.keys(options).length > 0"
 			class="options"
-			placement="bottom-start"
+			placement="bottom-end"
 			:options="options"
 			@click="emitChange"
 		></v-contextual-menu>


### PR DESCRIPTION
- Fixes an issue where the Contextual Menu can run off the screen when associated with the Header Button
- Updated a styling issue where expected styles were not being applied to the icon within the Contextual Menu
- added tabs rule to .pretterrc so spaces do not override on save.