### PR TITLE
Console Error Fix with Icon Prop Type issue

### DIFF
--- a/src/components/progress-ring.vue
+++ b/src/components/progress-ring.vue
@@ -75,7 +75,7 @@ export default {
 		},
 		iconSize() {
 			// Material design icons should be rendered in increments of 6 for visual clarity
-			return 6 * Math.round(this.radius / 6) + 'px';
+			return 6 * Math.round(this.radius / 6);
 		}
 	}
 };


### PR DESCRIPTION
Icon property 'Size' does not expect a string with px, it just wants a number and throws an error here