### PR TITLE
Ability to make repeater rows duplicable

### DIFF
--- a/src/interfaces/repeater/input.vue
+++ b/src/interfaces/repeater/input.vue
@@ -15,11 +15,13 @@
 				:fields="repeaterFields"
 				:inline="inline"
 				:template="options.template"
+				:duplicable="options.duplicable"
 				:open="open === index"
 				:placeholder="options.placeholder"
 				@open="toggleOpen(index)"
 				@input="updateRow(index, $event)"
 				@remove="removeRow(index)"
+				@duplicate="duplicateRow(index)"
 			/>
 		</draggable>
 		<div v-if="addButtonVisible" class="add-new" @click="addRow">
@@ -117,6 +119,14 @@ export default {
 		removeRow(index) {
 			const newRows = clone(this.rows);
 			newRows.splice(index, 1);
+			this.rows = newRows;
+			this.emitValue();
+		},
+		duplicateRow(index) {
+			const newRows = clone(this.rows);
+			const duplicatedRow = clone(this.rows[index]);
+
+			newRows.splice(index + 1, 0, duplicatedRow);
 			this.rows = newRows;
 			this.emitValue();
 		},

--- a/src/interfaces/repeater/meta.json
+++ b/src/interfaces/repeater/meta.json
@@ -120,6 +120,12 @@
       "default": null,
       "advanced": true
     },
+    "duplicable": {
+      "name": "$t:duplicable",
+      "comment": "$t:duplicable_comment",
+      "interface": "switch",
+      "advanced": true
+    },
     "structure": {
       "name": "$t:structure",
       "comment": "$t:structure_comment",

--- a/src/interfaces/repeater/row.vue
+++ b/src/interfaces/repeater/row.vue
@@ -37,11 +37,16 @@
 					{{ showPlaceholder ? placeholder : displayValue }}
 				</button>
 			</div>
-			<button type="button" @click="$emit('remove')">
+
+			<v-contextual-menu
+				v-if="duplicable"
+				class="more-options"
+				placement="bottom-end"
+				:options="rowOptions"
+				@click="rowOptionsClicked"
+			></v-contextual-menu>
+			<button v-else type="button" @click="$emit('remove')">
 				<v-icon name="delete_outline" class="remove" />
-			</button>
-			<button v-if="duplicable" type="button" @click="$emit('duplicate')">
-				<v-icon name="queue" class="duplicate" />
 			</button>
 		</div>
 		<div v-if="inline === false" v-show="open" class="body">
@@ -112,6 +117,31 @@ export default {
 			});
 
 			return fieldsHaveValue === false;
+		},
+		rowOptions() {
+			return [
+				{
+					text: this.$t('delete'),
+					icon: 'delete_outline'
+				},
+				{
+					text: this.$t('duplicate'),
+					icon: 'control_point_duplicate'
+				}
+			];
+		}
+	},
+	methods: {
+		rowOptionsClicked(option) {
+			switch (option) {
+				case 0:
+					this.$emit('remove');
+					break;
+				case 1:
+					this.$emit('duplicate');
+					break;
+				default:
+			}
 		}
 	}
 };

--- a/src/interfaces/repeater/row.vue
+++ b/src/interfaces/repeater/row.vue
@@ -40,6 +40,9 @@
 			<button type="button" @click="$emit('remove')">
 				<v-icon name="delete_outline" class="remove" />
 			</button>
+			<button v-if="duplicable" type="button" @click="$emit('duplicate')">
+				<v-icon name="queue" class="duplicate" />
+			</button>
 		</div>
 		<div v-if="inline === false" v-show="open" class="body">
 			<v-form
@@ -73,6 +76,10 @@ export default {
 		template: {
 			type: String,
 			default: null
+		},
+		duplicable: {
+			type: Boolean,
+			default: false
 		},
 		open: {
 			type: Boolean,

--- a/src/lang/en-US/interfaces.json
+++ b/src/lang/en-US/interfaces.json
@@ -453,6 +453,8 @@
 			"fields_comment": "What fields to show in each repeated row",
 			"limit": "Limit",
 			"limit_comment": "Maximum amount of rows the user can add",
+			"duplicable": "Duplicable rows",
+			"duplicable_comment": "Whether to make rows duplicable or not",
 			"structure": "Structure",
 			"structure_comment": "Whether to save the JSON as an array of objects or single object with unique keys",
 			"structure_key": "Structure Key Field",


### PR DESCRIPTION
I have a usecase where it would be very useful to be able to duplicate rows

Repeater field creation/edition (`false` by default) : 
![image](https://user-images.githubusercontent.com/1765930/75463538-410bbf00-5986-11ea-8514-9b638a52917a.png)

Item creation/edition : 
![image](https://user-images.githubusercontent.com/1765930/75463784-8def9580-5986-11ea-8851-996eb48de3c1.png)
