### PR TITLE
Fix code interface syntax highlighting

### DIFF
--- a/src/interfaces/code/input.vue
+++ b/src/interfaces/code/input.vue
@@ -76,17 +76,14 @@ export default {
 		return {
 			lineCount: 0,
 
-			cmOptions: {
+			defaultOptions: {
 				tabSize: 4,
 				autoRefresh: true,
 				indentUnit: 4,
 				styleActiveLine: true,
-				lineNumbers: this.options.lineNumber,
-				readOnly: this.readonly ? 'nocursor' : false,
 				styleSelectedText: true,
 				line: true,
 				highlightSelectionMatches: { showToken: /\w/, annotateScrollbar: true },
-				mode: this.mode,
 				hintOptions: {
 					completeSingle: true
 				},
@@ -124,17 +121,13 @@ export default {
 			return this.options.language === 'application/json'
 				? 'text/javascript'
 				: this.options.language;
-		}
-	},
-	watch: {
-		options(newVal, oldVal) {
-			if (newVal.language !== oldVal.language) {
-				this.$set(this.cmOptions, 'mode', newVal.language);
-			}
-
-			if (newVal.lineNumber !== oldVal.lineNumber) {
-				this.$set(this.cmOptions, 'lineNumbers', newVal.lineNumber);
-			}
+		},
+		cmOptions() {
+			return Object.assign({}, this.defaultOptions, {
+				lineNumbers: this.options.lineNumber,
+				readOnly: this.readonly ? 'nocursor' : false,
+				mode: this.mode
+			});
 		}
 	},
 	mounted() {


### PR DESCRIPTION
Hello,

If I add a code interface (javascript mode) to my collection, when editing/creating an item I get no syntax highlighting.
This is because `mode` is undefined here : 
https://github.com/directus/app/blob/master/src/interfaces/code/input.vue#L89

`mode` is a computed so it's undefined before `data()` is executed.

With this pattern you also have to use some imperative code in a watcher to keep the data object in sync.

Instead I used a computed.
I hope this doesn't introduce any side effects.
