### PR TITLE
Fix code interface template

### DIFF
--- a/src/interfaces/code/meta.json
+++ b/src/interfaces/code/meta.json
@@ -25,7 +25,7 @@
     "template": {
       "name": "$t:template",
       "comment": "$t:template_comment",
-      "interface": "json",
+      "interface": "code",
       "options": {
         "language": "text/plain"
       }


### PR DESCRIPTION
Use code interface for template to allow any template syntax (not just valid json)
(as discussed with @rijkvanzanten on slack)