### PR TITLE
Fix m2o interface not acknowledging readonly property

### DIFF
--- a/src/interfaces/many-to-one/input.vue
+++ b/src/interfaces/many-to-one/input.vue
@@ -21,7 +21,7 @@
 			/>
 
 			<button
-				v-if="count > options.threshold"
+				v-if="!readonly && count > options.threshold"
 				type="button"
 				@click="listingActive = true"
 			></button>


### PR DESCRIPTION
When the count of items exceeds the configured threshold option, a button is
inserted that does not respect the `readonly` property of the interface. This
fixes the behavior by leaving out the button whenever `readonly` is `true`.