### PR TITLE
Fix filter parameter usage in item select component

### DIFF
--- a/src/components/item-select/item-select.vue
+++ b/src/components/item-select/item-select.vue
@@ -292,7 +292,7 @@ export default {
 			}
 
 			if (this.filters.length > 0) {
-				params.filters = formatFilters(this.filters);
+				Object.assign(params, formatFilters(this.filters));
 			}
 
 			if (this.collection === 'directus_files') {


### PR DESCRIPTION
Using the `:filters` property of `v-item-select` is broken because the filter query parameters are built incorrectly. This fix makes sure the item filters are correctly merged into the `params` object.