### PR TITLE
Allow no matches in getFieldsFromTemplate

### DIFF
--- a/src/helpers/get-fields-from-template.js
+++ b/src/helpers/get-fields-from-template.js
@@ -10,6 +10,11 @@
 export default function getFieldsFromTemplate(string) {
 	const regex = /{{(.*?)}}/g;
 	let fields = string.match(regex);
+
+	if (!Array.isArray(fields)) {
+		return [];
+	}
+
 	fields = fields.map(field => {
 		return field
 			.replace(/{{/g, '')


### PR DESCRIPTION
Hello,

If I create a repeater row with a template like this : 
![image](https://user-images.githubusercontent.com/1765930/76069363-0fe94b00-5f93-11ea-9efe-f9caa56726d5.png)

I get this error 
```
TypeError: Cannot read property 'map' of null
    at getFieldsFromTemplate (get-fields-from-template.js?1581:18)
```

Indeed `getFieldsFromTemplate` only works when the `string` argument contains mustaches.

My fix : 
If no mustache-matches are found in `string` we return an empty array.