### PR TITLE
fix: repeater row should propagate width attribute to v-ext-input

### DIFF
--- a/src/interfaces/repeater/row.vue
+++ b/src/interfaces/repeater/row.vue
@@ -20,6 +20,7 @@
 						:fields="fields"
 						:values="row"
 						:length="field.length"
+						:width="field.width"
 						@input="
 							$emit('input', {
 								field: field.field,


### PR DESCRIPTION
Shouldn't the width attribute from the field definition always be propagated as it can be set in the repeater field model when creating/updating? Seems like `half` is a very sane default, can't believe I never noticed this before.

![image](https://user-images.githubusercontent.com/334/76773253-7e53b780-67a2-11ea-926c-66e8331f63dc.png)
