### PR TITLE
Fix bug (use collec. w/out icon in collec. list)

### DIFF
--- a/src/components/sidebars/nav-sidebar/nav-sidebar.vue
+++ b/src/components/sidebars/nav-sidebar/nav-sidebar.vue
@@ -112,7 +112,7 @@ export default {
 						return {
 							link: `/${this.currentProjectKey}/collections/${collection}`,
 							name: this.$helpers.formatCollection(collection),
-							icon: collectionInfo.icon
+							icon: collectionInfo ? collectionInfo.icon : null
 						};
 					})
 				};


### PR DESCRIPTION
When you add collection without icon in collection listing, the nav-sidebar crash.