### PR TITLE
fix translation on popup and inscrease debounce

### DIFF
--- a/src/components/item-select/item-select.vue
+++ b/src/components/item-select/item-select.vue
@@ -254,7 +254,7 @@ export default {
 
 		this.fetchItems();
 
-		this.setSearchQuery = debounce(this.setSearchQuery, 550);
+		this.setSearchQuery = debounce(this.setSearchQuery, 850);
 
 		// Fetch the total number of items in this collection, so we can accurately render the load more
 		// button

--- a/src/interfaces/translation/input.vue
+++ b/src/interfaces/translation/input.vue
@@ -154,6 +154,15 @@ export default {
 				})
 				.filter(i => i);
 
+			// if there is new langauge added, then need to push to the results
+			value.forEach(after => {
+				const languageKey = after[languageField];
+				const before = newValue.find(i => i[languageField] === languageKey);
+				if (!before) {
+					newValue.push(after);
+				}
+			});
+
 			this.$emit('input', newValue);
 		},
 		async fetchInitial() {

--- a/src/interfaces/translation/input.vue
+++ b/src/interfaces/translation/input.vue
@@ -93,7 +93,7 @@ export default {
 			deep: true,
 			handler(value) {
 				if (value) {
-					this.$emit('input', value);
+					this.emitValue(value);
 				}
 			}
 		}
@@ -131,13 +131,43 @@ export default {
 				this.relationalChanges = [...this.relationalChanges, update];
 			}
 		},
+		emitValue(value) {
+			if (this.initialValues.length == 0) {
+				this.$emit('input', value);
+				return;
+			}
+
+			// This is the key in the nested related object that holds the parent item again
+			const languageField = this.options.languageField;
+
+			const newValue = this.initialValues
+				.map(before => {
+					const languageKey = before[languageField];
+
+					// Check if the current item was saved before
+					const after = value.find(i => i[languageField] === languageKey);
+
+					if (after) {
+						return merge({}, before, after);
+					}
+					return before;
+				})
+				.filter(i => i);
+
+			this.$emit('input', newValue);
+		},
 		async fetchInitial() {
 			if (this.relationshipSetup === false) {
 				return;
 			}
 
-			if (this.newItem) {
+			/*if (this.newItem) {
 				this.initialValues = [];
+				return;
+			}*/
+
+			if (this.values && this.values[this.relation.field_one.field]) {
+				this.initialValues = this.values[this.relation.field_one.field];
 				return;
 			}
 


### PR DESCRIPTION
The idea is that in most of the case the translation data have been fetched and it can be access from the `values` passed from its parent component or interface, so there is not need to use `newItem` for checking the values. 

Regarding to the issue on modal, I think the issue is that it didn't emit the whole value it was stored.

changing the debounce as I found that in the item-select model, if I typed "syd" and tried to delete "yd" and typed other "xx", the result will looks very funny. Thinking most of the case, around 1 seconds waiting still fine for the user. 