### PR TITLE
Feature: Add new filter option for m2m interface 

### DIFF
--- a/src/components/item-select/item-select.vue
+++ b/src/components/item-select/item-select.vue
@@ -284,15 +284,12 @@ export default {
 			const params = {
 				limit: 200,
 				offset: options.offset,
-				meta: '*'
+				meta: '*',
+				...(this.filters.length > 0 ? formatFilters(this.filters) : {})
 			};
 
 			if (this.searchQuery.length > 0) {
 				params.q = this.searchQuery;
-			}
-
-			if (this.filters.length > 0) {
-				params.filters = formatFilters(this.filters);
 			}
 
 			if (this.collection === 'directus_files') {

--- a/src/helpers/format-filters.js
+++ b/src/helpers/format-filters.js
@@ -27,3 +27,40 @@ export default function formatFilters(filters) {
 
 	return parsedFilters;
 }
+
+/**
+ * Parse array of filters in syntax used by SDK in the array of filters objects
+ * @param  {Array} filters  The filters to parse
+ * @return {Object}         The filters as object array
+ *
+ * @example
+ *
+ * 'filter[title][contains]=Directus'
+ *
+ * parseFilters(filters);
+ * // => [
+ *       {
+ *         field: 'title',
+ *         operator: 'contains',
+ *         value: 'Directus'
+ *       }
+ *     ];
+ *   }
+ */
+export function parseFilters(filters) {
+	const parsedFilters = [],
+		filterRegExp = /filter\[(.*)\]\[(.*)\]=(.*)/;
+
+	filters.forEach(filter => {
+		let match = filterRegExp.exec(filter);
+		if (match.length == 4) {
+			parsedFilters.push({
+				field: match[1],
+				operator: match[2],
+				value: match[3]
+			});
+		}
+	});
+
+	return parsedFilters;
+}

--- a/src/interfaces/many-to-many/input.vue
+++ b/src/interfaces/many-to-many/input.vue
@@ -109,7 +109,7 @@
 			v-if="selectExisting"
 			:fields="visibleFieldNames"
 			:collection="relation.junction.collection_one.collection"
-			:filters="[]"
+			:filters="filters"
 			:value="stagedSelection || selectionPrimaryKeys"
 			@input="stageSelection"
 			@done="closeSelection"
@@ -149,6 +149,7 @@
 
 <script>
 import mixin from '@directus/extension-toolkit/mixins/interface';
+import { parseFilters } from '@/helpers/format-filters';
 import { diff } from 'deep-object-diff';
 import shortid from 'shortid';
 import { get, find, orderBy, cloneDeep, mapValues, merge, difference } from 'lodash';
@@ -215,6 +216,14 @@ export default {
 
 		visibleFieldNames() {
 			return this.visibleFields.map(field => field.field);
+		},
+
+		filters() {
+			return (
+				(this.options.filters &&
+					parseFilters(this.options.filters.split(',').map(val => val.trim()))) ||
+				[]
+			);
 		},
 
 		// The name of the field that holds the primary key in the related (not JT) collection

--- a/src/interfaces/many-to-many/meta.json
+++ b/src/interfaces/many-to-many/meta.json
@@ -30,6 +30,14 @@
       "comment": "$t:allow_select_comment",
       "interface": "switch",
       "default": true
-    }
+	},
+    "filters": {
+	   "name": "$t:filters",
+	   "comment": "$t:filters_comment",
+	   "interface": "text-input",
+	   "options": {
+	      "placeholder": "$t:filters_placeholder"
+	   }
+	}
   }
 }

--- a/src/lang/de-DE/interfaces.json
+++ b/src/lang/de-DE/interfaces.json
@@ -295,7 +295,10 @@
 			"allow_create": "Erstellen erlauben",
 			"allow_create_comment": "Dem Benutzer erlauben, ein neues Element aus dieser Schnittstelle zu erstellen",
 			"allow_select": "Auswahl erlauben",
-			"allow_select_comment": "Dem Benutzer erlauben, ein vorhandenes Element auszuwählen"
+			"allow_select_comment": "Dem Benutzer erlauben, ein vorhandenes Element auszuwählen",
+			"filters": "Filter",
+			"filters_comment": "Filterausdrücke (kommasepariert) wie beschrieben unter https://docs.directus.io/api/query/filter.html",
+			"filters_placeholder": "Filter für die angebotenen Einträge in der Beziehung"
 		},
 		"many-to-one": {
 			"m2o": "n:1-Beziehung",

--- a/src/lang/en-US/interfaces.json
+++ b/src/lang/en-US/interfaces.json
@@ -295,7 +295,10 @@
 			"allow_create": "Allow Create",
 			"allow_create_comment": "Allow the user to create a new item from this interface",
 			"allow_select": "Allow Select",
-			"allow_select_comment": "Allow the user to select an existing item"
+			"allow_select_comment": "Allow the user to select an existing item",
+			"filters": "Filters",
+			"filters_comment": "Filter expressions (comma-separated) as described at https://docs.directus.io/api/query/filter.html",
+			"filters_placeholder": "Filters for items to provide"
 		},
 		"many-to-one": {
 			"m2o": "Many to One",


### PR DESCRIPTION
Add new filter option for m2m interface to be able to configure the default filter for the relations in the collections.

This allows to specify comma separated list of filters as described in https://docs.directus.io/api/query/filter.html, e.g. 

`filter[category][eq]=development,filter[category][eq]=consulting`

The item list provided for selection is filtered then with help of these filters.

Following improvements I can imagine:
- Instead of using the text input, the repeater can be used to specify the filters (similar to translations)
- Since I'm not familiar with i18n concept of options, I put only english and german versions in these pull request. Other languages can be extended. 

Best regards