### PR TITLE
Fix an issue where the column display would not be sorted in the field order.

### DIFF
--- a/src/components/items.vue
+++ b/src/components/items.vue
@@ -147,8 +147,13 @@ export default {
 		},
 		fields() {
 			const fields = this.$store.state.collections[this.collection].fields;
+			const sortedValues = Object.values(fields).sort((a, b) => (a.sort < b.sort ? -1 : 1));
+			const sortedFields = {};
+			for (let field of sortedValues) {
+				sortedFields[field.field] = field;
+			}
 			return (
-				mapValues(fields, field => ({
+				mapValues(sortedFields, field => ({
 					...field,
 					name: this.$helpers.formatField(field.field, field.collection)
 				})) || {}


### PR DESCRIPTION
Currently, the order of the columns in the list of items is not determined. With this fix, the columns will now be displayed in the order of the fields.