### PR TITLE
Fix sudden item creation/duplication when editing O2M items

### DIFF
--- a/src/interfaces/one-to-many/input.vue
+++ b/src/interfaces/one-to-many/input.vue
@@ -397,7 +397,7 @@ export default {
 
 			if (isNewItem === false) {
 				const collection = this.relation.collection_many.collection;
-				const res = await this.$api.getItem(collection, primaryKey, { fields: '*.*.*' });
+				const res = await this.$api.getItem(collection, primaryKey, { fields: '*.*' });
 				const item = res.data;
 
 				values = merge({}, item, values);


### PR DESCRIPTION
**Issue**
This solves a long-standing issue for us with using O2M inputs in the Directus App where suddenly, empty or partially duplicated items were created in the database when editing an item with deep(er) relations to other items leading to further corruption of database items down the road.

For example, a schema I'm using looks something like this:
* ProductGroup.configuredProducts --> ConfiguredProduct (O2M)
* ConfiguredProduct.product --> Product (M2O)
* Product.media --> Media (M2M)

If I open an existing ProductGroup, the O2M input for `.configuredProducts` is initialized. If I then start editing an existing ConfiguredProduct (e.g. modifying its name) and save the ProductGroup, suddenly a new instance of Product is created.

**Cause**
The initial value for an O2M input is retrieved through the API with `*.*` for its fields parameter:
https://github.com/directus/app/blob/f36db073b6d47bd3b3a9f40edc65333ba9e503fe/src/interfaces/one-to-many/input.vue#L334-L343

However, when you start editing an item, the fields parameter is set to `*.*.*`:
https://github.com/directus/app/blob/f36db073b6d47bd3b3a9f40edc65333ba9e503fe/src/interfaces/one-to-many/input.vue#L398-L404

In the example I gave above, this means that whereas initially the field `ConfiguredProduct.product.media` was missing, it is now loaded since we went a level deeper.

Eventually this will trip up delta/diff calculations for the changes in the object here:
https://github.com/directus/app/blob/f36db073b6d47bd3b3a9f40edc65333ba9e503fe/src/interfaces/one-to-many/input.vue#L507

In my example, because the `after` value now contains a `product.media` field, this is included in the delta output which is sent to the API as a `PATCH` request, resulting in a *new* product being created instead of just updating the ConfiguredProduct item.

**Solution**
By changing the fields parameter to `*.*`, it now matches the initial value as loaded by the O2M input and no erroneous deltas are generated by `emitValue`. This fixes all my issues with empty items being created.

I've not encountered any case in my models where this leads to new/other issues in the interface.