### PR TITLE
safari no longer crashes when parsing file created_on date field. 

### DIFF
--- a/src/interfaces/file/input.vue
+++ b/src/interfaces/file/input.vue
@@ -136,7 +136,7 @@ export default {
 					.pop()
 					.toUpperCase() +
 				' • ' +
-				this.$d(new Date(this.image.uploaded_on), 'short')
+				this.$d(new Date(this.image.uploaded_on.replace(/-/g, '/')), 'short')
 			);
 		},
 		subtitleExtra() {


### PR DESCRIPTION
fixed error which caused safari to crash when parsing image.uploaded_on date string. More info here:
https://stackoverflow.com/questions/4310953/invalid-date-in-safari