### PR TITLE
Fix WYSIWYG undefined editor on value update within oneToMany (#2870)

### DIFF
--- a/src/interfaces/wysiwyg/input.vue
+++ b/src/interfaces/wysiwyg/input.vue
@@ -4,7 +4,7 @@
 			ref="editorElement"
 			:init="initOptions"
 			:value="value"
-			@onKeyUp="updateValue"
+			@onKeyUp="planToUpdateValue"
 			@onExecCommand="updateValue"
 			@onBlur="updateValue"
 			@onPaste="updateValue"
@@ -273,7 +273,7 @@ export default {
 		}
 	},
 	created() {
-		this.updateValue = debounce(this.updateValue, 200);
+		this.planToUpdateValue = debounce(this.updateValue, 200);
 	},
 	methods: {
 		updateValue() {
@@ -298,7 +298,6 @@ export default {
 			this.selectCallback = async () => {
 				// restore tinymce dialog display
 				document.querySelector('.tox.tox-tinymce-aux').style.display = 'block';
-				console.log(this);
 				let id;
 
 				if (typeof this.selectedFile === 'object') {


### PR DESCRIPTION
Hello,

A solution to the issue #2870. I renamed the debouned updateValue as  "planToUpdateValue" and keep it only on the keyUp event to preserve good performance. I think that the other events should trigger value update immediatly. 
Hope you are ok with that.

Also i removed the "console.log" that i have forgotten previously. Sorry for the inconvenient.