### PR TITLE
Fixing time distance error with formatDistance on Activity and Event pages

### DIFF
--- a/src/components/activity/activity.vue
+++ b/src/components/activity/activity.vue
@@ -246,7 +246,7 @@ export default {
 			this.comment = '';
 		},
 		getRelativeTimeFromNow(date) {
-			return formatDistance(new Date(), date, { addSuffix: true });
+			return formatDistance(date, new Date(), { addSuffix: true });
 		}
 	}
 };

--- a/src/layouts/timeline/Event.vue
+++ b/src/layouts/timeline/Event.vue
@@ -45,7 +45,7 @@ export default {
 	},
 	computed: {
 		time() {
-			return formatDistance(new Date(), this.data.time);
+			return formatDistance(this.data.time, new Date());
 		}
 	}
 };


### PR DESCRIPTION
As indicated [here](https://date-fns.org/v2.14.0/docs/formatDistance), the syntax of the `formatDistance(...)` function was swapped in `v2.0.0`, therefore leading to confusing statements such as _"in five months"_ instead of _"five months ago"_ on both the Activity and Event pages.