### PR TITLE
Missing 'identity' method import in the timeline options view

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-	plugins: [require("autoprefixer")]
+	plugins: [require('autoprefixer')]
 };

--- a/src/layouts/timeline/options.vue
+++ b/src/layouts/timeline/options.vue
@@ -51,7 +51,7 @@
 
 <script>
 import mixin from '@directus/extension-toolkit/mixins/layout';
-import { mapValues, pickBy, keys } from 'lodash';
+import { mapValues, pickBy, keys, identity } from 'lodash';
 
 export default {
 	mixins: [mixin],

--- a/src/main.js
+++ b/src/main.js
@@ -36,14 +36,14 @@ window._ = lodash;
 // Export modules on demand to externl scripts
 // Sample Usage: let _ = $directus.import('lodash');
 window.$directus = window.$directus || {};
-window.$directus.import = (module) => {
+window.$directus.import = module => {
 	const modules = {
-		"api": api,
-		"axios": axios,
-		"lodash": lodash,
-		"notify": notify,
-		"router": router,
-		"store": store
+		api: api,
+		axios: axios,
+		lodash: lodash,
+		notify: notify,
+		router: router,
+		store: store
 	};
 	if (!module) return modules;
 	else return modules[module];


### PR DESCRIPTION
I noticed the timeline view wasn't working for any of my collections. There was a reference error in the console: "identity is not defined at a.dateOptions (options.vue:98)". I added 'identity' to the import statement, just like in layout/calendar/options.vue. I verified this change by running a build and pointing to my api endpoint.

The changes to postcss.config.js and main.js were from running `yarn lint` on node v13.14, not related to the bug. Let me know if I need to add more info.