### PR TITLE
fix relative time handling

### DIFF
--- a/src/components/activity/activity.vue
+++ b/src/components/activity/activity.vue
@@ -246,7 +246,7 @@ export default {
 			this.comment = '';
 		},
 		getRelativeTimeFromNow(date) {
-			return formatDistance(new Date(), date, { addSuffix: true });
+			return formatDistance(date, new Date(), { addSuffix: true });
 		}
 	}
 };

--- a/src/routes/item.vue
+++ b/src/routes/item.vue
@@ -839,7 +839,9 @@ export default {
 				.then(({ activity, revisions }) => {
 					return {
 						activity: activity.map(act => {
-							const date = new Date(act.action_on);
+							const date = new Date(
+								/Z$/.test(act.action_on) ? act.action_on : act.action_on + 'Z'
+							);
 							let name;
 
 							if (act.action_by) {


### PR DESCRIPTION
this PR fixes 2 problems in the activity sidebar:
- past and future were mixed up, directus would always show changes "in ... days"
- server returns UTC times (which is good), but client interprets them in the OS timezone.